### PR TITLE
Normalizing whitespace in lightning components

### DIFF
--- a/src/aura/CampaignListApp/CampaignListApp.app
+++ b/src/aura/CampaignListApp/CampaignListApp.app
@@ -1,3 +1,3 @@
 <aura:application access="GLOBAL" extends="ltng:outApp">
-	<aura:dependency resource="c:CampaignListCmp"/>
+    <aura:dependency resource="c:CampaignListCmp"/>
 </aura:application>

--- a/src/aura/CampaignListCmp/CampaignListCmp.cmp
+++ b/src/aura/CampaignListCmp/CampaignListCmp.cmp
@@ -1,59 +1,59 @@
 <aura:component controller="CampaignListBuilder_CTRL" >
     <aura:attribute name="campaignId" type="String" />
-	<aura:attribute name="campaign" type="Campaign"/>
+    <aura:attribute name="campaign" type="Campaign"/>
     <aura:attribute name="csegRoot" type="CSegment"/>
     <aura:attribute name="csegRootOriginal" type="CSegment"/>
     <aura:attribute name="csegExcludes" type="CSegment"/>
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
-    <aura:handler event="c:addCSegmentEvent" action="{!c.handleAddCSegmentEvent}"/>   
-    
-    
+    <aura:handler event="c:addCSegmentEvent" action="{!c.handleAddCSegmentEvent}"/>
+
+
     <!-- <ltng:require styles="/resource/bssf1" /> -->
-	
+
     <!-- gets an error when loading here, but ok from the vfpage!!!!
     <ltng:require scripts="/resource/LightningDesignSystem/assets/styles/salesforce-lightning-design-system.css" />
     -->
-    
-    
+
+
     <!-- only needed by autocomplete component, but lightning bug fails to load it there -->
-    <ltng:require scripts="/resource/jquery,/resource/jqueryui/jqueryui/jquery-ui.js," 
+    <ltng:require scripts="/resource/jquery,/resource/jqueryui/jqueryui/jquery-ui.js,"
                   styles="/resource/jqueryui/jqueryui/jquery-ui.css" />
 
-	<div class="slds">
-		<!-- PAGE HEADER -->
-		<div class="slds-page-header" role="banner">
-			<!-- LAYOUT GRID -->
-			<div class="slds-grid">
-				<!-- GRID COL -->
-				<div class="slds-col">
-					<!-- HEADING AREA -->                    
-					<!-- MEDIA OBJECT = FIGURE + BODY -->
-					<div class="slds-media">
-						<div class="slds-media__figure">
-							<c:svg class="slds-icon slds-icon--large slds-icon-standard-user" 
+    <div class="slds">
+        <!-- PAGE HEADER -->
+        <div class="slds-page-header" role="banner">
+            <!-- LAYOUT GRID -->
+            <div class="slds-grid">
+                <!-- GRID COL -->
+                <div class="slds-col">
+                    <!-- HEADING AREA -->
+                    <!-- MEDIA OBJECT = FIGURE + BODY -->
+                    <div class="slds-media">
+                        <div class="slds-media__figure">
+                            <c:svg class="slds-icon slds-icon--large slds-icon-standard-user"
                                    xlinkHref="/resource/LightningDesignSystem/assets/icons/standard-sprite/svg/symbols.svg#campaign" />
-						</div>
-						<div class="slds-media__body">
-							<p class="slds-text-heading--label">Campaign List</p>
-							<h1 class="slds-text-heading--medium">{!v.campaign.Name}</h1>
-						</div>
-					</div>
-					<!-- / MEDIA OBJECT -->
-					<!-- HEADING AREA -->
-				</div>
-				<!-- GRID COL -->
-				<div class="slds-col slds-no-flex slds-align-middle">
-					<div class="slds-button-group" role="group">
+                        </div>
+                        <div class="slds-media__body">
+                            <p class="slds-text-heading--label">Campaign List</p>
+                            <h1 class="slds-text-heading--medium">{!v.campaign.Name}</h1>
+                        </div>
+                    </div>
+                    <!-- / MEDIA OBJECT -->
+                    <!-- HEADING AREA -->
+                </div>
+                <!-- GRID COL -->
+                <div class="slds-col slds-no-flex slds-align-middle">
+                    <div class="slds-button-group" role="group">
                         <ui:button aura:id="buttonSave" buttonTitle="Click to save and return to campaign" class="slds-button slds-button--neutral" label="Save &amp; Close" press="{!c.saveAndClose}" />
                         <ui:button aura:id="buttonClose" buttonTitle="Click to return to campaign" class="slds-button slds-button--neutral" label="Close" press="{!c.close}" />
-					</div>
-				</div>
-				<!-- / GRID COL -->
-			</div>
-			<!-- / LAYOUT GRID -->
-		</div>
-		<!-- / PAGE HEADER -->
-            
+                    </div>
+                </div>
+                <!-- / GRID COL -->
+            </div>
+            <!-- / LAYOUT GRID -->
+        </div>
+        <!-- / PAGE HEADER -->
+
         <p/>
         <c:SourceMultiList group="{!v.csegRoot}" />
         <h3>Excludes</h3>

--- a/src/aura/CampaignListCmp/CampaignListCmpController.js
+++ b/src/aura/CampaignListCmp/CampaignListCmpController.js
@@ -1,18 +1,18 @@
 ({
-	doInit: function(component, event, helper) {
+    doInit: function(component, event, helper) {
         helper.loadCampaignInfo(component);
-	},
-    
+    },
+
     saveAndClose: function(component, event, helper) {
         helper.saveCSegmentTree(component, true);
     },
-    
+
     close: function(component, event, helper) {
         helper.close(component);
     },
-    
+
     // event handler to add a group csegment
     handleAddCSegmentEvent: function(component, event, helper) {
         helper.addGroup(component, event);
-    },    
+    },
 })

--- a/src/aura/Source/Source.cmp
+++ b/src/aura/Source/Source.cmp
@@ -1,15 +1,15 @@
 <aura:component >
     <aura:attribute name="source" type="CSegment"/>
- 	<aura:registerEvent name="deleteCSegmentEvent" type="c:deleteCSegmentEvent"/>
-    
- 	<div class="filter slds-form--inline">
+    <aura:registerEvent name="deleteCSegmentEvent" type="c:deleteCSegmentEvent"/>
+
+    <div class="filter slds-form--inline">
         <div class="slds-form-element">
             <ui:inputSelect class="slds-select" aura:id="sourceType" change="{!c.handleSourceType}">
                 <ui:inputSelectOption text="Select Source Type"/>
                 <ui:inputSelectOption text="Campaign" label="Campaign" value="{!v.source.Segment.Source_Type__c == 'Campaign'}" />
                 <ui:inputSelectOption text="Report" label="Report" value="{!v.source.Segment.Source_Type__c == 'Report'}" />
             </ui:inputSelect>
-        </div>        
+        </div>
         <div class="slds-form-element" style="width:60%">
             <aura:if isTrue="{!v.source.Segment.Source_Type__c == 'Report'}">
                 <c:autocomplete sObjectType="Report" autocompleteEvent="{!c.handleAutocomplete}" placeholder="find..." value="{!v.source.sourceName}" fields="" />
@@ -17,7 +17,7 @@
             <aura:if isTrue="{!v.source.Segment.Source_Type__c == 'Campaign'}">
                 <c:autocomplete sObjectType="Campaign" autocompleteEvent="{!c.handleAutocomplete}" placeholder="find..." value="{!v.source.sourceName}" fields="" />
             </aura:if>
-        </div>        
+        </div>
         <ui:button aura:id="deleteSource" buttonTitle="Delete Source" class="slds-button--small" label="del" press="{!c.delete}"/>
-	</div>
+    </div>
 </aura:component>

--- a/src/aura/Source/SourceController.js
+++ b/src/aura/Source/SourceController.js
@@ -1,26 +1,26 @@
 ({
-	handleSourceType: function(component, event, helper) {
-		var selectCmp = component.find("sourceType");
+    handleSourceType: function(component, event, helper) {
+        var selectCmp = component.find("sourceType");
         var source = component.get('v.source');
         source.Segment.Source_Type__c = selectCmp.get("v.value");
         component.set("v.source", source);
-	},
-    
+    },
+
     delete: function(component, event, helper) {
         var source = component.get('v.source');
-    	if (source == null)
-    		return;
-    
-	    var event = $A.get("e.c:deleteCSegmentEvent");
-		event.setParams({ "cseg" : source });
-		event.fire();
+        if (source == null)
+            return;
 
-	},
-       
+        var event = $A.get("e.c:deleteCSegmentEvent");
+        event.setParams({ "cseg" : source });
+        event.fire();
+
+    },
+
     handleAutocomplete: function(component, event) {
         var source = component.get('v.source');
         var selOpt = event.getParam('selectedOption');
-        source.Segment.Source_ID__c = selOpt.value;  
+        source.Segment.Source_ID__c = selOpt.value;
         source.sourceName = selOpt.label;
         component.set("v.source", source);
     },

--- a/src/aura/SourceMultiList/SourceMultiList.cmp
+++ b/src/aura/SourceMultiList/SourceMultiList.cmp
@@ -1,15 +1,15 @@
 <aura:component >
     <aura:attribute name="group" type="CSegment" />
- 	<aura:registerEvent name="addCSegmentEvent" type="c:addCSegmentEvent"/>
+    <aura:registerEvent name="addCSegmentEvent" type="c:addCSegmentEvent"/>
     <aura:handler event="c:deleteCSegmentEvent" action="{!c.handleDeleteCSegmentEvent}"/>
-    
-	<div class="filter-list slds-theme--shade">
-	    <!-- <span><i>SourceMultiList {!v.group.Segment.Id}, Children: {!v.group.listChildCSegments.length}</i></span> -->
+
+    <div class="filter-list slds-theme--shade">
+        <!-- <span><i>SourceMultiList {!v.group.Segment.Id}, Children: {!v.group.listChildCSegments.length}</i></span> -->
         <div class="{!v.group.Segment.Operation__c == 'OR' ? 'group-filters or' : 'group-filters and'}">
             <aura:if isTrue="{!v.group.Segment.Operation__c == 'SOURCE'}">
                 <!-- <span><i>A multilist node that is a SOURCE!</i></span> -->
                 <c:Source source="{!v.group}" />
-            <aura:set attribute="else">        
+            <aura:set attribute="else">
                 <aura:iteration items="{!v.group.listChildCSegments}" var="cseg">
                     <aura:if isTrue="{!cseg.Segment.Operation__c  == 'SOURCE'}">
                         <c:Source source="{!cseg}" />
@@ -18,11 +18,11 @@
                     </aura:set>
                     </aura:if>
                     <div class="operationLabel" >{!v.group.Segment.Operation__c == 'AND' ? 'and' : 'or'}</div>
-                </aura:iteration>            
+                </aura:iteration>
             </aura:set>
             </aura:if>
             <aura:if isTrue="{! v.group.Segment.Operation__c != 'OR'}">
-	            <ui:button aura:id="button" buttonTitle="Click to add a source" class="slds-button--small" label="Add new source" press="{!c.addSource}"/>
+                <ui:button aura:id="button" buttonTitle="Click to add a source" class="slds-button--small" label="Add new source" press="{!c.addSource}"/>
             </aura:if>
             <aura:if isTrue="{! v.group.parentCSegment == v.group.rootCSegment}">
                 <ui:button aura:id="button" buttonTitle="Click to add a group" class="slds-button--small" label="Add new group" press="{!c.addGroup}"/>

--- a/src/aura/SourceMultiList/SourceMultiListController.js
+++ b/src/aura/SourceMultiList/SourceMultiListController.js
@@ -1,15 +1,15 @@
 ({
     // handler for the Add Source button.
     // creates a new source, and if needed, a parent group.
-	addSource: function(component, event, helper) {
-		var group = component.get('v.group');
-        
+    addSource: function(component, event, helper) {
+        var group = component.get('v.group');
+
         // our current segment may be a group or a source.
         // so if we are not a group, we have to add one.
         if (group.Segment.Operation__c == 'SOURCE') {
             var segNew = {Operation__c:'AND'};
             var csegNew = {
-                Segment: segNew, 
+                Segment: segNew,
                 listChildCSegments: [],
                 rootCSegment: group.rootCSegment,
                 parentCSegment: group.parentCSegment
@@ -17,7 +17,7 @@
             helper.insertParentInTree(group, csegNew);
             group = csegNew;
         }
-        
+
         var segNew = {Operation__c:'SOURCE'};
         var csegNew = {
             Segment: segNew,
@@ -26,26 +26,26 @@
             parentCSegment: group.parentCSegment
         };
         helper.insertChildInTree(group, csegNew);
-		        
+
         component.set('v.group', group);
-	},
-    
+    },
+
     // handler for the Add Group button.
     // fires an addCSegmentEvent to allow its parent do the work.
-    addGroup: function(component, event, helper) {        
+    addGroup: function(component, event, helper) {
         var group = component.get('v.group');
-    	if (group == null)
-    		return;
-	    var event = $A.get("e.c:addCSegmentEvent");
-		event.setParams({ "cseg" : group });
-		event.fire();
-		return;
-	},
-    
+        if (group == null)
+            return;
+        var event = $A.get("e.c:addCSegmentEvent");
+        event.setParams({ "cseg" : group });
+        event.fire();
+        return;
+    },
+
     // event handler to see if deleted cseg was one of our children (or ourself!)
     handleDeleteCSegmentEvent: function(component, event) {
-		var cseg = event.getParam("cseg");
-		var group = component.get('v.group');
+        var cseg = event.getParam("cseg");
+        var group = component.get('v.group');
         if (cseg != null && group != null) {
             // deleting ourself?
             if (cseg == group) {
@@ -56,7 +56,7 @@
                     cseg.Segment.Source_Type__c = null;
                     cseg.listChildCSegments = [];
                 }
-                
+
             }
             else if (group.listChildCSegments != null) {
                 var i = group.listChildCSegments.indexOf(cseg);
@@ -66,13 +66,13 @@
                     if (group.listChildCSegments.length == 0) {
                         var event = $A.get("e.c:deleteCSegmentEvent");
                         event.setParams({ "cseg" : group });
-                        event.fire();                        
+                        event.fire();
                     }
                 }
             }
-        	// to force rerender
+            // to force rerender
             component.set('v.group', group);
         }
     },
-    
+
 })

--- a/src/aura/SourceMultiList/SourceMultiListHelper.js
+++ b/src/aura/SourceMultiList/SourceMultiListHelper.js
@@ -1,20 +1,20 @@
 ({
-	insertParentInTree : function(cseg, csegNewParent) {
-		// replace cseg from its parent's children with csegNewParent
-		var csegOldParent = cseg.parentCSegment;
+    insertParentInTree : function(cseg, csegNewParent) {
+        // replace cseg from its parent's children with csegNewParent
+        var csegOldParent = cseg.parentCSegment;
         var i = csegOldParent.listChildCSegments.indexOf(cseg);
         csegOldParent.listChildCSegments[i] = csegNewParent;
 
         // make sure the new parent has its correct parent
         csegNewParent.parentCSegment = csegOldParent;
-        
-		// add cseg to new parent's children
+
+        // add cseg to new parent's children
         csegNewParent.listChildCSegments.push(cseg);
 
         // set new Parent for cseg
         cseg.parentCSegment = csegNewParent;
-	},
-    
+    },
+
     insertChildInTree : function (cseg, csegNewChild) {
         csegNewChild.parentCSegment = cseg;
         cseg.listChildCSegments.push(csegNewChild);

--- a/src/aura/autocomplete/autocomplete.cmp
+++ b/src/aura/autocomplete/autocomplete.cmp
@@ -5,14 +5,14 @@
     <aura:attribute name="inputLabel" type="String" default="" description="Label for text input"/>
     <aura:attribute name="placeholder" type="String" default="" description="Placeholder text to display when empty" />
     <aura:attribute name="value" type="String" description="initial value to display" />
-    
+
     <aura:attribute name="ready" type="Boolean" default="false" description="Used to check if resources have been loaded"/>
 
     <aura:registerEvent name="autocompleteEvent" type="c:autocompleteEvent"/>
-        
-    <ltng:require scripts="/resource/jquery,/resource/jqueryui/jqueryui/jquery-ui.js," 
+
+    <ltng:require scripts="/resource/jquery,/resource/jqueryui/jqueryui/jquery-ui.js,"
                   styles="/resource/jqueryui/jqueryui/jquery-ui.css" afterScriptsLoaded="{!c.doInit}" />
-	<div style="display:inline"> <!-- this div needed by autocomplete to work! -->
+    <div style="display:inline"> <!-- this div needed by autocomplete to work! -->
         <ui:inputText value="{!v.value}" label="{!v.inputLabel}" placeholder="{!v.placeholder}"
                       class="autocomplete slds-form-element__control slds-input" />
     </div>

--- a/src/aura/autocomplete/autocompleteController.js
+++ b/src/aura/autocomplete/autocompleteController.js
@@ -1,7 +1,7 @@
 ({
-    
-    doInit: function(component, event, helper) {       
-       	helper.initHandlers(component);
+
+    doInit: function(component, event, helper) {
+        helper.initHandlers(component);
     }
-    
+
 })

--- a/src/aura/autocomplete/autocompleteHelper.js
+++ b/src/aura/autocomplete/autocompleteHelper.js
@@ -1,54 +1,54 @@
-({  
+({
     initHandlers: function(component) {
         if (typeof jQuery !== "undefined" && typeof $j === "undefined") {
             $j = jQuery.noConflict(true);;
-        }        
-        
+        }
+
         if (typeof $j === "undefined")
             return;
-        
+
         var ctx = component.getElement();
-        
+
         $j(".autocomplete", ctx).autocomplete({
             minLength: 2,
             delay: 500,
             source: function(request, response) {
                 var action = component.get("c.getSuggestions");
                 var fieldsToGet = component.get("v.fields");
-               
+
                 action.setParams({
                     "sObjectType": component.get("v.sObjectType"),
                     "term": request.term,
                     "fieldsToGet": fieldsToGet.join(),
                     "limitSize": component.get("v.limit")
                 });
-                
+
                 action.setCallback(this, function(a) {
-                	var suggestions = a.getReturnValue();
+                    var suggestions = a.getReturnValue();
                     suggestions.forEach(function(s) {
                         s["label"] = s.Name,
                         s["value"] = s.Id
                     });
                     response(suggestions);
                 });
-                
+
                 $A.run(function() {
-                    $A.enqueueAction(action); 
+                    $A.enqueueAction(action);
                 });
             },
-            select: function(event, ui) {  
+            select: function(event, ui) {
                 event.preventDefault();
                 var ctx = component.getElement();
                 $j(".autocomplete", ctx).val(ui.item.label);
-                    
+
                 var selectionEvent = component.getEvent("autocompleteEvent");
                 selectionEvent.setParams({
-                    "selectedOption": ui.item 
+                    "selectedOption": ui.item
                 });
                 selectionEvent.fire();
             },
             focus: function(event, ui) {
-            	event.preventDefault(); // to stop the textbox from being updated with the item's value.    
+                event.preventDefault(); // to stop the textbox from being updated with the item's value.
             },
         });
     }

--- a/src/aura/autocomplete/autocompleteRenderer.js
+++ b/src/aura/autocomplete/autocompleteRenderer.js
@@ -1,7 +1,7 @@
 ({
-    
-	afterRender : function(component, helper) {
-	    this.superAfterRender();
+
+    afterRender : function(component, helper) {
+        this.superAfterRender();
         helper.initHandlers(component);
-	}
+    }
 })

--- a/src/aura/autocompleteEvent/autocompleteEvent.evt
+++ b/src/aura/autocompleteEvent/autocompleteEvent.evt
@@ -1,3 +1,3 @@
 <aura:event type="COMPONENT">
-	<aura:attribute name="selectedOption" type="Object"/>
+    <aura:attribute name="selectedOption" type="Object"/>
 </aura:event>


### PR DESCRIPTION
The whitespace in the aura components was a big mess: most files were indented with a mix of tabs and spaces, and many lines had trailing whitespace.

I have normalized the whitespace by replacing all tab characters with 4 spaces, and removed trailing whitespace from the ends of lines.

It may be a good idea to review this PR by asking Github to ignore whitespace changes in the diff.  This will show an empty diff, which indicates that all of the changes are only changes in whitespace.  You can view the diff with whitespace changes omitted with the w=1 url parameter, or just use this link: https://github.com/SalesforceFoundation/CampaignTools/pull/31/files?w=1