### PR TITLE
Ability to specify grouping segments as negated operations

### DIFF
--- a/src/classes/CampaignListSegment.cls
+++ b/src/classes/CampaignListSegment.cls
@@ -105,16 +105,6 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
     }
 
     /**
-     * @description Is this segment intended to exclude members or negate
-     * child segments?
-     *
-     * @return Boolean
-     */
-    public Boolean isExclusion() {
-        return isExclusion;
-    }
-
-    /**
      * @description Add a child segment to this segment
      * @param term The segment to add as a child.
      * @return void

--- a/src/classes/CampaignListSegment.cls
+++ b/src/classes/CampaignListSegment.cls
@@ -47,6 +47,12 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
     private Id parentId;
 
     /**
+     * @description True if this source is intended to be used to exclude
+     * members from the campaign list.  False, otherwise.
+     */
+    private Boolean isExclusion;
+
+    /**
      * @description This segment's children segments, if it has any
      */
     private List<CampaignList.Segment> children = new List<CampaignList.Segment>();
@@ -57,10 +63,11 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
      * @param rootSegmentId The id of the "campaign list" this segment belongs to
      * @param parentId The immediate parent of this segment
      */
-    public CampaignListSegment(Id segmentId, Id rootSegmentId, Id parentId) {
+    public CampaignListSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion) {
         this.segmentId = segmentId;
         this.rootSegmentId = rootSegmentId;
         this.parentId = parentId;
+        this.isExclusion = isExclusion;
     }
 
     /**
@@ -85,6 +92,16 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
      */
     public Id getParentId() {
         return parentId;
+    }
+
+    /**
+     * @description Is this segment intended to exclude members or negate
+     * child segments?
+     *
+     * @return Boolean
+     */
+    public Boolean isExclusion() {
+        return isExclusion;
     }
 
     /**
@@ -145,27 +162,58 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * @param rootSegmentId The id of the "campaign list" this segment belongs to
          * @param parentId The immediate parent of this segment
          */
-        public AndSegment(Id segmentId, Id rootSegmentId, Id parentId) {
-            super(segmentId, rootSegmentId, parentId);
+        public AndSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion) {
+            super(segmentId, rootSegmentId, parentId, isExclusion);
         }
 
         /**
          * @description Determine whether the given CampaignListMember meets
          * the criteria of all of the terms within this AND grouping of
-         * segments.
+         * segments.  A CampaignListSegment can only return a valid result if
+         * it has at least one valid child.  If this CampaignListSegment is
+         * not valid, then this method will return null.
          *
          * @param m The CampaignListMember to determine whether eligible for inclusion in a campaign list
-         * @return Boolean (true if the given CampaignListMember is eligible by the criteria of this segment, false otherwise)
+         * @return Boolean (true if the given CampaignListMember is eligible by the criteria of this segment, false if it isn't eligible, or null if the segment is not valid)
          */
         public override Boolean meetsCriteria(CampaignList.Member m) {
-            for (CampaignList.Segment child : children) {
-                if (!child.meetsCriteria(m)) {
-                    return false;
-                }
-            }
-            return true;
-        }
+            /*
+             Since this node can only return a valid result if it has at
+             least one valid child, we will keep track of the number of
+             valid children we encounter while iterating over this node's
+             children (if any).  As we ask each child node whether the given
+             member meets its criteria, we check if the child node returns a
+             valid result (i.e., not null).  If the child node returns null,
+             indicating an invalid child node, we skip that child node in
+             the iteration and do not increment the valid child node
+             counter.  If we did get a valid result (i.e. a boolean) from
+             the child node, we use that result to potentially invalidate
+             our assumption that this node should return true (since a valid
+             'and' node is false if at least one of its children is false,
+             otherwise true).  Since the child node returned a valid result,
+             we increment the valid child count.  Finally, after we've
+             iterated over all of the child nodes, we return null if this
+             node did not have at least one valid child, otherwise we
+             return the accumulated result of this node, negating it if
+             this node is negated (i.e. if isExclusion is true).
+            */
+            Boolean meetsCriteria = true;
+            Integer numberOfValidChildren = 0;
 
+            List<Boolean> childCriteria = new List<Boolean>();
+            for (CampaignList.Segment child : children) {
+                Boolean childMeetsCriteria = child.meetsCriteria(m);
+                if (null == childMeetsCriteria) continue;
+                meetsCriteria &= childMeetsCriteria;
+                numberOfValidChildren++;
+            }
+
+            if (numberOfValidChildren < 1) {
+                return null;
+            }
+
+            return isExclusion ^ meetsCriteria;
+        }
     }
 
     /**
@@ -181,22 +229,57 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * @param rootSegmentId The id of the "campaign list" this segment belongs to
          * @param parentId The immediate parent of this segment
          */
-        public OrSegment(Id segmentId, Id rootSegmentId, Id parentId) {
-            super(segmentId, rootSegmentId, parentId);
+        public OrSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion) {
+            super(segmentId, rootSegmentId, parentId, isExclusion);
         }
 
         /**
-         * @description Determine whether the given CampaignListMember meets the criteria of all of the terms within this OR grouping of segments.
+         * @description Determine whether the given CampaignListMember meets
+         * the criteria of all of the terms within this OR grouping of
+         * segments.  A CampaignListSegment can only return a valid result if
+         * it has at least one valid child.  If this CampaignListSegment is
+         * not valid, then this method will return null.
+         *
          * @param m The CampaignListMember to determine whether eligible for inclusion in a campaign list
-         * @return Boolean (true if the given CampaignListMember is eligible by the criteria of this segment, false otherwise)
+         * @return Boolean (true if the given CampaignListMember is eligible by the criteria of this segment, false if it isn't eligible, or null if the segment is not valid)
          */
         public override Boolean meetsCriteria(CampaignList.Member m) {
+            /*
+             Since this node can only return a valid result if it has at
+             least one valid child, we will keep track of the number of
+             valid children we encounter while iterating over this node's
+             children (if any).  As we ask each child node whether the given
+             member meets its criteria, we check if the child node returns a
+             valid result (i.e., not null).  If the child node returns null,
+             indicating an invalid child node, we skip that child node in
+             the iteration and do not increment the valid child node
+             counter.  If we did get a valid result (i.e. a boolean) from
+             the child node, we use that result to potentially invalidate
+             our assumption that this node should return false (since a valid
+             'or' node is true if at least one of its children is true,
+             otherwise false).  Since the child node returned a valid result,
+             we increment the valid child count.  Finally, after we've
+             iterated over all of the child nodes, we return null if this
+             node did not have at least one valid child, otherwise we
+             return the accumulated result of this node, negating it if
+             this node is negated (i.e. if isExclusion is true).
+            */
+            Boolean meetsCriteria = false;
+            Integer numberOfValidChildren = 0;
+
+            List<Boolean> childCriteria = new List<Boolean>();
             for (CampaignList.Segment child : children) {
-                if (child.meetsCriteria(m)) {
-                    return true;
-                }
+                Boolean childMeetsCriteria = child.meetsCriteria(m);
+                if (null == childMeetsCriteria) continue;
+                meetsCriteria |= childMeetsCriteria;
+                numberOfValidChildren++;
             }
-            return false;
+
+            if (numberOfValidChildren < 1) {
+                return null;
+            }
+
+            return isExclusion ^ meetsCriteria;
         }
     }
 
@@ -214,21 +297,14 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
         private Id sourceId;
 
         /**
-         * @description True if this source is intended to be used to exclude
-         * members from the campaign list.  False, otherwise.
-         */
-        private Boolean isExclusion;
-
-        /**
          * @description Construct a SourceSegment
          * @param segmentId The id of this segment
          * @param rootSegmentId The id of the "campaign list" this segment belongs to
          * @param parentId The immediate parent of this segment
          */
-        public SourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Id sourceId, Boolean isExclusion) {
-            super(segmentId, rootSegmentId, parentId);
+        public SourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion, Id sourceId) {
+            super(segmentId, rootSegmentId, parentId, isExclusion);
             this.sourceId = sourceId;
-            this.isExclusion = isExclusion;
         }
 
         /**
@@ -237,16 +313,6 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          */
         public Id getSourceId() {
             return sourceId;
-        }
-
-        /**
-         * @description Is this source segment intended to exclude members
-         * found in the source?
-         *
-         * @return Boolean
-         */
-        public Boolean isExclusion() {
-            return isExclusion;
         }
 
         /**
@@ -299,8 +365,8 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * @param sourceId The id of the source Campaign
          * @param isExclusion True if this source is intended to exclude members that are found in the given campaign.  False, otherwise.
          */
-        public CampaignSourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Id sourceId, Boolean isExclusion) {
-            super(segmentId, rootSegmentId, parentId, sourceId, isExclusion);
+        public CampaignSourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion, Id sourceId) {
+            super(segmentId, rootSegmentId, parentId, isExclusion, sourceId);
         }
 
         /**
@@ -345,8 +411,8 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * @param isExclusion True if this source is intended to exclude members that are found in the given report.  False, otherwise.
          * @param columnName the name of the column in the source report that holds the id of the related Contact or Lead
          */
-        public ReportSourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Id sourceId, Boolean isExclusion, String columnName) {
-            super(segmentId, rootSegmentId, parentId, sourceId, isExclusion);
+        public ReportSourceSegment(Id segmentId, Id rootSegmentId, Id parentId, Boolean isExclusion, Id sourceId, String columnName) {
+            super(segmentId, rootSegmentId, parentId, isExclusion, sourceId);
             this.columnName = columnName;
         }
 

--- a/src/classes/CampaignListSegment.cls
+++ b/src/classes/CampaignListSegment.cls
@@ -105,6 +105,16 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
     }
 
     /**
+     * @description Is this segment intended to exclude members or negate
+     * child segments?
+     *
+     * @return Boolean
+     */
+    public Boolean isExclusion() {
+        return isExclusion;
+    }
+
+    /**
      * @description Add a child segment to this segment
      * @param term The segment to add as a child.
      * @return void

--- a/src/classes/CampaignListSegment.cls
+++ b/src/classes/CampaignListSegment.cls
@@ -206,6 +206,7 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
                 if (null == childMeetsCriteria) continue;
                 meetsCriteria &= childMeetsCriteria;
                 numberOfValidChildren++;
+                if (!meetsCriteria) break;
             }
 
             if (numberOfValidChildren < 1) {
@@ -273,6 +274,7 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
                 if (null == childMeetsCriteria) continue;
                 meetsCriteria |= childMeetsCriteria;
                 numberOfValidChildren++;
+                if (meetsCriteria) break;
             }
 
             if (numberOfValidChildren < 1) {

--- a/src/classes/CampaignListSegmentMapper.cls
+++ b/src/classes/CampaignListSegmentMapper.cls
@@ -138,20 +138,19 @@ public class CampaignListSegmentMapper implements CampaignList.SegmentMapper {
         Id segmentId = segment.Id;
         Id rootSegmentId = segment.Root_Segment__c;
         Id parentId = segment.Parent_Segment__c;
+        Boolean isExclusion = segment.Exclude_Source__c;
 
         if ('OR' == segment.Operation__c) {
-            return new CampaignListSegment.OrSegment(segmentId, rootSegmentId, parentId);
+            return new CampaignListSegment.OrSegment(segmentId, rootSegmentId, parentId, isExclusion);
         } else if ('AND' == segment.Operation__c) {
-            return new CampaignListSegment.AndSegment(segmentId, rootSegmentId, parentId);
+            return new CampaignListSegment.AndSegment(segmentId, rootSegmentId, parentId, isExclusion);
         } else if ('SOURCE' == segment.Operation__c) {
             Id sourceId = (Id) segment.Source_ID__c;
-            Boolean isExcluded = segment.Exclude_Source__c;
-
             if (Campaign.sObjectType == sourceId.getSObjectType()) {
-                return new CampaignListSegment.CampaignSourceSegment(segmentId, rootSegmentId, parentId, sourceId, isExcluded);
+                return new CampaignListSegment.CampaignSourceSegment(segmentId, rootSegmentId, parentId, isExclusion, sourceId);
             } else if (Report.sObjectType == sourceId.getSObjectType()) {
                 String columnName = segment.Report_Column_Name__c;
-                return new CampaignListSegment.ReportSourceSegment(segmentId, rootSegmentId, parentId, sourceId, isExcluded, columnName);
+                return new CampaignListSegment.ReportSourceSegment(segmentId, rootSegmentId, parentId, isExclusion, sourceId, columnName);
             }
         }
         throw new CampaignList.InvalidSegmentSObjectException('Invalid Segment__c object');

--- a/src/classes/CampaignListSegment_TEST.cls
+++ b/src/classes/CampaignListSegment_TEST.cls
@@ -37,12 +37,14 @@ private class CampaignListSegment_TEST {
         CampaignListSegment.AndSegment segment = new CampaignListSegment.AndSegment(
             segmentId,
             rootSegmentId,
-            parentId
+            parentId,
+            false
         );
 
         System.assertEquals(segmentId, segment.getId());
         System.assertEquals(rootSegmentId, segment.getRootSegmentId());
         System.assertEquals(parentId, segment.getParentId());
+        System.assertEquals(false, segment.isExclusion());
     }
 
     private static testMethod void testOrSegment() {
@@ -53,12 +55,14 @@ private class CampaignListSegment_TEST {
         CampaignListSegment.OrSegment segment = new CampaignListSegment.OrSegment(
             segmentId,
             rootSegmentId,
-            parentId
+            parentId,
+            false
         );
 
         System.assertEquals(segmentId, segment.getId());
         System.assertEquals(rootSegmentId, segment.getRootSegmentId());
         System.assertEquals(parentId, segment.getParentId());
+        System.assertEquals(false, segment.isExclusion());
     }
 
     private static testMethod void testCampaignSourceSegment() {
@@ -71,8 +75,8 @@ private class CampaignListSegment_TEST {
             segmentId,
             rootSegmentId,
             parentId,
-            sourceId,
-            false
+            false,
+            sourceId
         );
 
         System.assertEquals(segmentId, segment.getId());
@@ -104,8 +108,8 @@ private class CampaignListSegment_TEST {
             segmentId,
             rootSegmentId,
             parentId,
-            sourceId,
             false,
+            sourceId,
             'test_column_name'
         );
 

--- a/src/classes/CampaignListSegment_TEST2.cls
+++ b/src/classes/CampaignListSegment_TEST2.cls
@@ -1225,49 +1225,6 @@ private class CampaignListSegment_TEST2 {
         return getTestMembersWithSources(A, B, C, D, null);
     }
 
-    private static CampaignListSegment createOrSegment() {
-        return createSegment('OR', false);
-    }
-
-    private static CampaignListSegment createAndSegment() {
-        return createSegment('AND', false);
-    }
-
-    private static CampaignListSegment createSourceSegment(Id sourceId) {
-        return createSegment('SOURCE', false, sourceId);
-    }
-
-    private static CampaignListSegment createExcludedSourceSegment(Id sourceId) {
-        return createSegment('SOURCE', true, sourceId);
-    }
-
-    private static CampaignListSegment createSegment(String operator, Boolean isExclusion) {
-        return createSegment(operator, isExclusion, null);
-    }
-
-    private static CampaignListSegment createSegment(String operator, Boolean isExclusion, Id sourceId) {
-        if ('OR' == operator) {
-            return new CampaignListSegment.OrSegment(null, null, null);
-        } else if ('AND' == operator) {
-            return new CampaignListSegment.AndSegment(null, null, null);
-        } else if ('SOURCE' == operator) {
-            return new CampaignListSegment.CampaignSourceSegment(null, null, null, sourceId, isExclusion);
-        }
-        return null;
-    }
-
-    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B) {
-        return getTestMembersWithSources(A, B, null, null, null);
-    }
-
-    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C) {
-        return getTestMembersWithSources(A, B, C, null, null);
-    }
-
-    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C, Id D) {
-        return getTestMembersWithSources(A, B, C, D, null);
-    }
-
     private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C, Id D, Id E) {
         Map<String, CampaignList.Member> members = new Map<String, CampaignList.Member>();
 

--- a/src/classes/CampaignListSegment_TEST2.cls
+++ b/src/classes/CampaignListSegment_TEST2.cls
@@ -338,6 +338,893 @@ private class CampaignListSegment_TEST2 {
         System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B, C, D, E)')));
     }
 
+    private static testMethod void testNegatedOrWithNegatedEmptyAndAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (NOT AND)
+         *         (NOT SOURCE A)
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (AND)
+         *     (SOURCE A)
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createNegatedAndSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createAndSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testNegatedOrWithNegatedEmptyAndAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (NOT (AND))
+         *         (SOURCE A)
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (AND)
+         *     (NOT (SOURCE A))
+         * )
+         */
+
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createNegatedAndSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createAndSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testNegatedOrWithNegatedEmptyOrAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (NOT (OR))
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (OR)
+         *     (SOURCE A)
+         * )
+         */
+
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createNegatedOrSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createOrSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testNegatedOrWithNegatedEmptyOrAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (NOT (OR))
+         *         (SOURCE A)
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (OR)
+         *     (NOT (SOURCE A))
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createNegatedOrSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createOrSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+
+    private static testMethod void testNegatedOrWithEmptyAndAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (AND)
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (NOT (AND))
+         *     (SOURCE A)
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createAndSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createNegatedAndSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+
+    private static testMethod void testNegatedOrWithEmptyAndAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (AND)
+         *         (SOURCE A)
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (NOT (AND))
+         *     (NOT (SOURCE A))
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createAndSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createNegatedAndSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testNegatedOrWithEmptyOrAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (OR)
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (NOT (OR))
+         *     (SOURCE A)
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createOrSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createNegatedOrSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testNegatedOrWithEmptyOrAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (NOT
+         *     (OR
+         *         (OR)
+         *         (SOURCE A)
+         *     )
+         * )
+         *
+         * Equivalent to:
+         * (AND
+         *     (NOT (OR))
+         *     (NOT (SOURCE A))
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createNegatedOrSegment();
+        rootSegment.addChild(createOrSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createAndSegment();
+        rootSegment2.addChild(createNegatedOrSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithNegatedEmptyAndAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (NOT (AND))
+         *     (NOT (SOURCE A))
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (AND)
+         *         (SOURCE A)
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createOrSegment();
+        rootSegment.addChild(createNegatedAndSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createAndSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithNegatedEmptyAndAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (NOT (AND))
+         *     (SOURCE A)
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (AND)
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignListSegment rootSegment = createOrSegment();
+        rootSegment.addChild(createNegatedAndSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createAndSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithNegatedEmptyOrAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (NOT (OR))
+         *     (NOT (SOURCE A))
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (OR)
+         *         (SOURCE A)
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createNegatedOrSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createOrSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithNegatedEmptyOrAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (NOT (OR))
+         *     (SOURCE A)
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (OR)
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createNegatedOrSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createOrSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithEmptyAndAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (AND)
+         *     (NOT (SOURCE A))
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (NOT (AND))
+         *         (SOURCE A)
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createAndSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createNegatedAndSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithEmptyAndAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (AND)
+         *     (SOURCE A)
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (NOT (AND))
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createAndSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createNegatedAndSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static testMethod void testOrWithEmptyOrAndExcludedSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (OR)
+         *     (NOT (SOURCE A))
+         * )
+         *
+         * (NOT
+         *     (AND
+         *         (NOT (OR))
+         *         (SOURCE A)
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createOrSegment());
+        rootSegment.addChild(createExcludedSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createNegatedOrSegment());
+        rootSegment2.addChild(createSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (), (B)
+         *
+         * Expected to not meet criteria:
+         * (A), (A, B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('()')));
+
+    }
+
+    private static testMethod void testOrWithEmptyOrAndSource() {
+        /*
+         * Criteria tree as s-expression:
+         * (OR
+         *     (OR)
+         *     (SOURCE A)
+         * )
+         *
+         * Equivalent to:
+         * (NOT
+         *     (AND
+         *         (NOT (OR))
+         *         (NOT (SOURCE A))
+         *     )
+         * )
+         */
+
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
+        CampaignList.Segment rootSegment = createOrSegment();
+        rootSegment.addChild(createOrSegment());
+        rootSegment.addChild(createSourceSegment(A));
+
+        CampaignListSegment rootSegment2 = createNegatedAndSegment();
+        rootSegment2.addChild(createNegatedOrSegment());
+        rootSegment2.addChild(createExcludedSourceSegment(A));
+
+        /*
+         * Test members:
+         * (), (A), (B), (A, B)
+         *
+         * Expected to meet criteria:
+         * (A), (A, B)
+         *
+         * Expected to not meet criteria:
+         * (), (B)
+         */
+
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
+
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment.meetsCriteria(members.get('()')));
+
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('(B)')));
+        System.assertEquals(true, rootSegment2.meetsCriteria(members.get('(A, B)')));
+        System.assertEquals(false, rootSegment2.meetsCriteria(members.get('()')));
+    }
+
+    private static CampaignListSegment createOrSegment() {
+        return createSegment('OR', false);
+    }
+
+    private static CampaignListSegment createNegatedOrSegment() {
+        return createSegment('OR', true);
+    }
+
+    private static CampaignListSegment createAndSegment() {
+        return createSegment('AND', false);
+    }
+
+    private static CampaignListSegment createNegatedAndSegment() {
+        return createSegment('AND', true);
+    }
+
+    private static CampaignListSegment createSourceSegment(Id sourceId) {
+        return createSegment('SOURCE', false, sourceId);
+    }
+
+    private static CampaignListSegment createExcludedSourceSegment(Id sourceId) {
+        return createSegment('SOURCE', true, sourceId);
+    }
+
+    private static CampaignListSegment createSegment(String operator, Boolean isExclusion) {
+        return createSegment(operator, isExclusion, null);
+    }
+
+    private static CampaignListSegment createSegment(String operator, Boolean isExclusion, Id sourceId) {
+        if ('OR' == operator) {
+            return new CampaignListSegment.OrSegment(null, null, null, isExclusion);
+        } else if ('AND' == operator) {
+            return new CampaignListSegment.AndSegment(null, null, null, isExclusion);
+        } else if ('SOURCE' == operator) {
+            return new CampaignListSegment.CampaignSourceSegment(null, null, null, isExclusion, sourceId);
+        }
+        return null;
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B) {
+        return getTestMembersWithSources(A, B, null, null, null);
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C) {
+        return getTestMembersWithSources(A, B, C, null, null);
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C, Id D) {
+        return getTestMembersWithSources(A, B, C, D, null);
+    }
+
     private static CampaignListSegment createOrSegment() {
         return createSegment('OR', false);
     }

--- a/src/classes/CampaignListSegment_TEST2.cls
+++ b/src/classes/CampaignListSegment_TEST2.cls
@@ -35,19 +35,10 @@ private class CampaignListSegment_TEST2 {
          * (SOURCE A)
          */
 
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            null,
-            sourceAId,
-            false
-        );
-
-        CampaignListSegment rootSegment = sourceASegment;
+        CampaignListSegment rootSegment = createSourceSegment(A);
 
         /*
          * Test members:
@@ -60,13 +51,7 @@ private class CampaignListSegment_TEST2 {
          * (), (B)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            null,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
@@ -80,19 +65,10 @@ private class CampaignListSegment_TEST2 {
          * (NOT (SOURCE A))
          */
 
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            null,
-            sourceAId,
-            true
-        );
-
-        CampaignListSegment rootSegment = sourceASegment;
+        CampaignListSegment rootSegment = createExcludedSourceSegment(A);
 
         /*
          * Test members:
@@ -105,13 +81,7 @@ private class CampaignListSegment_TEST2 {
          * (A), (A, B)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            null,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
@@ -128,38 +98,13 @@ private class CampaignListSegment_TEST2 {
          * )
          */
 
-        Id andSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceCId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id C = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment andSegment = new CampaignListSegment.AndSegment(
-            andSegmentId,
-            null,
-            null
-        );
-
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            andSegmentId,
-            sourceAId,
-            false
-        );
-
-        CampaignListSegment sourceBSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceBSegmentId,
-            null,
-            andSegmentId,
-            sourceBId,
-            false
-        );
-
-        CampaignListSegment rootSegment = andSegment;
-        rootSegment.addChild(sourceASegment);
-        rootSegment.addChild(sourceBSegment);
+        CampaignListSegment rootSegment = createAndSegment();
+        rootSegment.addChild(createSourceSegment(A));
+        rootSegment.addChild(createSourceSegment(B));
 
         /*
          * Test members:
@@ -172,13 +117,7 @@ private class CampaignListSegment_TEST2 {
          * (), (A), (B), (C), (A, C), (B, C)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            sourceCId,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B, C);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B)')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, B, C)')));
@@ -200,38 +139,13 @@ private class CampaignListSegment_TEST2 {
          * )
          */
 
-        Id orSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceCId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id C = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment orSegment = new CampaignListSegment.OrSegment(
-            orSegmentId,
-            null,
-            null
-        );
-
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            orSegmentId,
-            sourceAId,
-            false
-        );
-
-        CampaignListSegment sourceBSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceBSegmentId,
-            null,
-            orSegmentId,
-            sourceBId,
-            false
-        );
-
-        CampaignListSegment rootSegment = orSegment;
-        rootSegment.addChild(sourceASegment);
-        rootSegment.addChild(sourceBSegment);
+        CampaignListSegment rootSegment = createOrSegment();
+        rootSegment.addChild(createSourceSegment(A));
+        rootSegment.addChild(createSourceSegment(B));
 
         /*
          * Test members:
@@ -244,13 +158,7 @@ private class CampaignListSegment_TEST2 {
          * (), (C)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            sourceCId,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B, C);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A)')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
@@ -271,38 +179,13 @@ private class CampaignListSegment_TEST2 {
          * )
          */
 
-        Id andSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceCId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id C = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment andSegment = new CampaignListSegment.AndSegment(
-            andSegmentId,
-            null,
-            null
-        );
-
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            andSegmentId,
-            sourceAId,
-            true
-        );
-
-        CampaignListSegment sourceBSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceBSegmentId,
-            null,
-            andSegmentId,
-            sourceBId,
-            false
-        );
-
-        CampaignListSegment rootSegment = andSegment;
-        rootSegment.addChild(sourceASegment);
-        rootSegment.addChild(sourceBSegment);
+        CampaignListSegment rootSegment = createAndSegment();
+        rootSegment.addChild(createExcludedSourceSegment(A));
+        rootSegment.addChild(createSourceSegment(B));
 
         /*
          * Test members:
@@ -315,13 +198,7 @@ private class CampaignListSegment_TEST2 {
          * (), (A), (C), (A, B), (A, C), (A, B, C)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            sourceCId,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B, C);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B, C)')));
@@ -342,38 +219,13 @@ private class CampaignListSegment_TEST2 {
          * )
          */
 
-        Id orSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceCId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id C = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment orSegment = new CampaignListSegment.OrSegment(
-            orSegmentId,
-            null,
-            null
-        );
-
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            orSegmentId,
-            sourceAId,
-            true
-        );
-
-        CampaignListSegment sourceBSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceBSegmentId,
-            null,
-            orSegmentId,
-            sourceBId,
-            false
-        );
-
-        CampaignListSegment rootSegment = orSegment;
-        rootSegment.addChild(sourceASegment);
-        rootSegment.addChild(sourceBSegment);
+        CampaignListSegment rootSegment = createOrSegment();
+        rootSegment.addChild(createExcludedSourceSegment(A));
+        rootSegment.addChild(createSourceSegment(B));
 
         /*
          * Test members:
@@ -386,13 +238,7 @@ private class CampaignListSegment_TEST2 {
          * (A), (A, C)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            sourceCId,
-            null,
-            null
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B, C);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('()')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(B)')));
@@ -419,76 +265,21 @@ private class CampaignListSegment_TEST2 {
          * )
          */
 
-        Id andSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id orSegment1Id = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id orSegment2Id = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceASegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceAId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceBSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceBId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceCSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceCId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceDSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id sourceDId = CampaignList_TEST.getNextId(Campaign.sObjectType);
-        Id sourceEId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id A = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id B = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id C = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id D = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id E = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignListSegment andSegment = new CampaignListSegment.AndSegment(
-            andSegmentId,
-            null,
-            null
-        );
-
-        CampaignListSegment orSegment1 = new CampaignListSegment.OrSegment(
-            orSegment1Id,
-            null,
-            andSegmentId
-        );
-
-        CampaignListSegment orSegment2 = new CampaignListSegment.OrSegment(
-            orSegment2Id,
-            null,
-            andSegmentId
-        );
-
-        CampaignListSegment sourceASegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceASegmentId,
-            null,
-            orSegment1Id,
-            sourceAId,
-            false
-        );
-
-        CampaignListSegment sourceBSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceBSegmentId,
-            null,
-            orSegment1Id,
-            sourceBId,
-            true
-        );
-
-        CampaignListSegment sourceCSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceCSegmentId,
-            null,
-            orSegment2Id,
-            sourceCId,
-            false
-        );
-
-        CampaignListSegment sourceDSegment = new CampaignListSegment.CampaignSourceSegment(
-            sourceDSegmentId,
-            null,
-            orSegment2Id,
-            sourceDId,
-            false
-        );
-
-        CampaignListSegment rootSegment = andSegment;
+        CampaignListSegment rootSegment = createAndSegment();
+        CampaignListSegment orSegment1 = createOrSegment();
+        orSegment1.addChild(createSourceSegment(A));
+        orSegment1.addChild(createExcludedSourceSegment(B));
+        CampaignListSegment orSegment2 = createOrSegment();
+        orSegment2.addChild(createSourceSegment(C));
+        orSegment2.addChild(createSourceSegment(D));
         rootSegment.addChild(orSegment1);
-        orSegment1.addChild(sourceASegment);
-        orSegment1.addChild(sourceBSegment);
         rootSegment.addChild(orSegment2);
-        orSegment2.addChild(sourceCSegment);
-        orSegment2.addChild(sourceDSegment);
 
         /*
          * Test members:
@@ -510,13 +301,7 @@ private class CampaignListSegment_TEST2 {
          * (B, D, E), (B, C, D, E)
          */
 
-        Map<String, CampaignListMember> members = getTestMembersWithSources(
-            sourceAId,
-            sourceBId,
-            sourceCId,
-            sourceDId,
-            sourceEId
-        );
+        Map<String, CampaignList.Member> members = getTestMembersWithSources(A, B, C, D, E);
 
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(C)')));
         System.assertEquals(true, rootSegment.meetsCriteria(members.get('(A, C)')));
@@ -553,8 +338,51 @@ private class CampaignListSegment_TEST2 {
         System.assertEquals(false, rootSegment.meetsCriteria(members.get('(B, C, D, E)')));
     }
 
-    private static Map<String, CampaignListMember> getTestMembersWithSources(Id A, Id B, Id C, Id D, Id E) {
-        Map<String, CampaignListMember> members = new Map<String, CampaignListMember>();
+    private static CampaignListSegment createOrSegment() {
+        return createSegment('OR', false);
+    }
+
+    private static CampaignListSegment createAndSegment() {
+        return createSegment('AND', false);
+    }
+
+    private static CampaignListSegment createSourceSegment(Id sourceId) {
+        return createSegment('SOURCE', false, sourceId);
+    }
+
+    private static CampaignListSegment createExcludedSourceSegment(Id sourceId) {
+        return createSegment('SOURCE', true, sourceId);
+    }
+
+    private static CampaignListSegment createSegment(String operator, Boolean isExclusion) {
+        return createSegment(operator, isExclusion, null);
+    }
+
+    private static CampaignListSegment createSegment(String operator, Boolean isExclusion, Id sourceId) {
+        if ('OR' == operator) {
+            return new CampaignListSegment.OrSegment(null, null, null);
+        } else if ('AND' == operator) {
+            return new CampaignListSegment.AndSegment(null, null, null);
+        } else if ('SOURCE' == operator) {
+            return new CampaignListSegment.CampaignSourceSegment(null, null, null, sourceId, isExclusion);
+        }
+        return null;
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B) {
+        return getTestMembersWithSources(A, B, null, null, null);
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C) {
+        return getTestMembersWithSources(A, B, C, null, null);
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C, Id D) {
+        return getTestMembersWithSources(A, B, C, D, null);
+    }
+
+    private static Map<String, CampaignList.Member> getTestMembersWithSources(Id A, Id B, Id C, Id D, Id E) {
+        Map<String, CampaignList.Member> members = new Map<String, CampaignList.Member>();
 
         members.put('()', getTestMemberWithSources(null, null, null, null, null));
 
@@ -602,7 +430,7 @@ private class CampaignListSegment_TEST2 {
         return members;
     }
 
-    private static CampaignListMember getTestMemberWithSources(Id A, Id B, Id C, Id D, Id E) {
+    private static CampaignList.Member getTestMemberWithSources(Id A, Id B, Id C, Id D, Id E) {
         CampaignListMember member = new CampaignListMember(null, null);
         if (null != A) {
             member.addSource(A, 'A');


### PR DESCRIPTION
**This commit is based on the work in #32.  Please review and merge that pull request before reviewing this one**

This adds functionality to CampaignListSegment that allows grouping segments to have their action negated.  It also handles the case where empty grouping nodes are included in the segment tree.  The behavior of meetsCriteria when it encounters grouping segments that are not themselves valid* is to ignore them and act as if those segments were not in the tree at all.

Since invalid* segments don't have a truth value when querying meetsCriteria(), this method will now return null for those segments.  This is handled internally in meetsCriteria() for all subtrees, but if for some reason the root segment itself was invalid* then meetsCriteria() would return null to the calling code.

*a valid segment, as far as meetsCriteria() is concerned, is one that has children and at least one of those children is valid. This means both empty grouping nodes are invalid, as well as grouping nodes where all of their children are invalid nodes.  meetsCriteria() simply can't return a result in cases like that.