### PR TITLE
Adding Campaign "last updated" field w/ mutex

### DIFF
--- a/src/classes/CampaignList.cls
+++ b/src/classes/CampaignList.cls
@@ -108,6 +108,7 @@ public abstract class CampaignList {
     private static ReportService reportService_x = (ReportService) Type.forName('ReportService').newInstance();
     private static MemberMapper memberMapper_x = new CampaignListMemberMapper();
     private static SegmentMapper segmentMapper_x = new CampaignListSegmentMapper();
+    private static Mutex.Factory mutexFactory_x = new Mutex.DefaultFactory();
 
     public static void setService(Service s) {
         service_x = s;
@@ -139,5 +140,13 @@ public abstract class CampaignList {
 
     public static SegmentMapper getSegmentMapper() {
         return segmentMapper_x;
+    }
+
+    public static void setMutexFactory(Mutex.Factory mutexFactory) {
+        mutexFactory_x = mutexFactory;
+    }
+
+    public static Mutex.Factory getMutexFactory() {
+        return mutexFactory_x;
     }
 }

--- a/src/classes/CampaignListService.cls
+++ b/src/classes/CampaignListService.cls
@@ -85,7 +85,10 @@ public class CampaignListService implements CampaignList.Service {
 
             if (!lockAcquired) {
                 throw new CampaignListUpdateAlreadyRunningException(
-                    'Could not update campaign ' + campaignId + ' because this campaign is locked by another campaign list update.'
+                    String.format(
+                        Label.CampaignToolsAlreadyRunningException,
+                        new List<String>{campaignId}
+                    )
                 );
             }
 
@@ -95,7 +98,10 @@ public class CampaignListService implements CampaignList.Service {
         } catch (Exception e) {
             System.debug(e.getStackTraceString());
             throw new CampaignListUpdateAlreadyRunningException(
-                'Could not update campaign ' + campaignId + '.',
+                String.format(
+                    Label.CampaignToolsCantUpdateException,
+                    new List<String>{campaignId}
+                ),
                 e
             );
         }

--- a/src/classes/CampaignListService.cls
+++ b/src/classes/CampaignListService.cls
@@ -79,9 +79,26 @@ public class CampaignListService implements CampaignList.Service {
         batchSequence.add(new CampaignListToCampaignBatch(campaignId, segmentTree), 10000);
         batchSequence.add(new DeleteCampaignListMembersBatch(rootSegmentId), 5000);
 
-        CampaignList.getService().updateCampaignStatus(campaignId, CampaignList.UpdateStatus.RUNNING);
+        try {
+            Mutex.MutexInterface m = CampaignList.getMutexFactory().create(campaignId, Campaign.Campaign_List_Mutex__c);
+            Boolean lockAcquired = m.acquireLock();
 
-        batchSequence.run();
+            if (!lockAcquired) {
+                throw new CampaignListUpdateAlreadyRunningException(
+                    'Could not update campaign ' + campaignId + ' because this campaign is locked by another campaign list update.'
+                );
+            }
+
+            CampaignList.getService().updateCampaignStatus(campaignId, CampaignList.UpdateStatus.RUNNING);
+            batchSequence.run();
+
+        } catch (Exception e) {
+            System.debug(e.getStackTraceString());
+            throw new CampaignListUpdateAlreadyRunningException(
+                'Could not update campaign ' + campaignId + '.',
+                e
+            );
+        }
     }
 
     /**
@@ -98,6 +115,13 @@ public class CampaignListService implements CampaignList.Service {
             Campaign_List_Update_Status__c = status.name()
         );
 
+        if (CampaignList.UpdateStatus.SUCCESS == status) {
+            c.Campaign_List_Last_Updated__c = DateTime.now();
+        }
+
         update c;
     }
+
+    public virtual class CustomException extends Exception {}
+    public class CampaignListUpdateAlreadyRunningException extends CustomException {}
 }

--- a/src/classes/CampaignListService.cls
+++ b/src/classes/CampaignListService.cls
@@ -96,7 +96,6 @@ public class CampaignListService implements CampaignList.Service {
             batchSequence.run();
 
         } catch (Exception e) {
-            System.debug(e.getStackTraceString());
             throw new CampaignListUpdateAlreadyRunningException(
                 String.format(
                     Label.CampaignToolsCantUpdateException,

--- a/src/classes/CampaignListService_TEST.cls
+++ b/src/classes/CampaignListService_TEST.cls
@@ -63,6 +63,13 @@ private class CampaignListService_TEST {
         CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
         CampaignList.setService(serviceStub);
 
+        CampaignList_TEST.MutexStub mutexStub = new CampaignList_TEST.MutexStub();
+        mutexStub.acquireLock = true;
+
+        CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
+        mutexFactory.m = mutexStub;
+        CampaignList.setMutexFactory(mutexFactory);
+
         CampaignListService service = new CampaignListService();
         service.updateCampaignFromCampaignList(destinationCampaignId, rootSegment.Id, bsStub);
 
@@ -70,6 +77,9 @@ private class CampaignListService_TEST {
         // running update
 
         System.assertEquals(destinationCampaignId, serviceStub.updatedCampaignId);
+        System.assertEquals(destinationCampaignId, mutexFactory.recordId);
+        System.assertEquals(Campaign.Campaign_List_Mutex__c, mutexFactory.mutexField);
+        System.assertEquals(1, mutexStub.acquireLockCalls);
         System.assertEquals(CampaignList.UpdateStatus.RUNNING, serviceStub.updatedStatus);
 
         // assert that the batches in this sequence exist in the expected

--- a/src/classes/CampaignListToCampaignBatch.cls
+++ b/src/classes/CampaignListToCampaignBatch.cls
@@ -102,10 +102,28 @@ public class CampaignListToCampaignBatch extends BatchableSequence.Batch impleme
     */
     public override void finish(Database.BatchableContext bc) {
         super.finish(bc);
-        CampaignList.getService().updateCampaignStatus(
-            campaignId,
-            CampaignList.UpdateStatus.SUCCESS
-        );
+        try {
+            CampaignList.getService().updateCampaignStatus(
+                campaignId,
+                CampaignList.UpdateStatus.SUCCESS
+            );
+
+            Mutex.MutexInterface m = CampaignList.getMutexFactory().create(campaignId, Campaign.Campaign_List_Mutex__c);
+            Boolean lockReleased = m.releaseLock();
+
+            if (!lockReleased) {
+                throw new CouldNotReleaseLockException(
+                    'Could not release lock on campaign ' + campaignId
+                );
+            }
+
+        } catch (Exception e) {
+            throw new CouldNotUpdateCampaignException(
+                'Could not finish updating campaign ' + campaignId,
+                e
+            );
+        }
+
     }
 
     /**
@@ -118,4 +136,8 @@ public class CampaignListToCampaignBatch extends BatchableSequence.Batch impleme
     public override Id executeBatch() {
         return Database.executeBatch(this, getScope());
     }
+
+    public virtual class CustomException extends Exception {}
+    public class CouldNotReleaseLockException extends CustomException {}
+    public class CouldNotUpdateCampaignException extends CustomException {}
 }

--- a/src/classes/CampaignListToCampaignBatch.cls
+++ b/src/classes/CampaignListToCampaignBatch.cls
@@ -113,13 +113,19 @@ public class CampaignListToCampaignBatch extends BatchableSequence.Batch impleme
 
             if (!lockReleased) {
                 throw new CouldNotReleaseLockException(
-                    'Could not release lock on campaign ' + campaignId
+                    String.format(
+                        Label.CampaignToolsReleaseLockException,
+                        new List<String>{campaignId}
+                    )
                 );
             }
 
         } catch (Exception e) {
             throw new CouldNotUpdateCampaignException(
-                'Could not finish updating campaign ' + campaignId,
+                String.format(
+                    Label.CampaignToolsCantFinishUpdateException,
+                    new List<String>{campaignId}
+                ),
                 e
             );
         }

--- a/src/classes/CampaignListToCampaignBatch_TEST.cls
+++ b/src/classes/CampaignListToCampaignBatch_TEST.cls
@@ -92,6 +92,13 @@ private class CampaignListToCampaignBatch_TEST {
     }
 
     public static testMethod void testExecuteBatch() {
+        CampaignList_TEST.MutexStub mutexStub = new CampaignList_TEST.MutexStub();
+        mutexStub.releaseLock = true;
+
+        CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
+        mutexFactory.m = mutexStub;
+        CampaignList.setMutexFactory(mutexFactory);
+
         CampaignList_TEST.SegmentStub rootSegment = new CampaignList_TEST.SegmentStub();
         CampaignListToCampaignBatch batch = new CampaignListToCampaignBatch(null, rootSegment);
         batch.setScope(200);
@@ -115,6 +122,13 @@ private class CampaignListToCampaignBatch_TEST {
         CampaignList_TEST.ServiceStub listServiceStub = new CampaignList_TEST.ServiceStub();
 
         CampaignList.setService(listServiceStub);
+
+        CampaignList_TEST.MutexStub mutexStub = new CampaignList_TEST.MutexStub();
+        mutexStub.releaseLock = true;
+
+        CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
+        mutexFactory.m = mutexStub;
+        CampaignList.setMutexFactory(mutexFactory);
 
         batch.finish(null);
 

--- a/src/classes/CampaignList_TEST.cls
+++ b/src/classes/CampaignList_TEST.cls
@@ -134,6 +134,38 @@ public class CampaignList_TEST {
         }
     }
 
+    public class MutexStubFactory implements Mutex.Factory {
+        public Id recordId;
+        public Schema.SObjectField mutexField;
+        public Mutex.MutexInterface m;
+        public Mutex.MutexInterface create(Id recordId, Schema.SObjectField mutexField) {
+            this.recordId = recordId;
+            this.mutexField = mutexField;
+            return m;
+        }
+    }
+
+    public class MutexStub implements Mutex.MutexInterface {
+        public Integer acquireLockCalls = 0;
+        public Integer releaseLockCalls = 0;
+        public Integer getLockTimeCalls = 0;
+        public Boolean acquireLock;
+        public Boolean releaseLock;
+        public DateTime lockTime;
+        public Boolean acquireLock() {
+            acquireLockCalls++;
+            return acquireLock;
+        }
+        public Boolean releaseLock() {
+            releaseLockCalls++;
+            return releaseLock;
+        }
+        public DateTime getLockTime() {
+            getLockTimeCalls++;
+            return lockTime;
+        }
+    }
+
     public class TestCampaign {
         public Campaign campaign;
         public List<Contact> contacts;

--- a/src/classes/Mutex.cls
+++ b/src/classes/Mutex.cls
@@ -1,0 +1,240 @@
+/*
+    Copyright (c) 2015 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @group Mutex
+ * @description Allows obtaining a mutex on a particular record, as long as that record has a mutex datetime field.  This relies on SELECT ... FOR UPDATE for concurrency control.
+ */
+public with sharing class Mutex implements MutexInterface {
+    /*
+     * @description The recordId of the record to be locked
+     */
+    private Id recordId;
+
+    /*
+     * @description The field on the record to be used to store the acquire time of the lock.  If this field is null, the record is not locked.
+     */
+    private Schema.SObjectField mutexField;
+
+    /*
+     * @description Construct a Mutex for a specific record and mutexField.  Note this does not lock the record-- you must call acquireLock() to attempt to lock the record.  mutexField is a DateTime field on the record to be locked.
+     *
+     * @param recordId The id of the record to be locked.
+     * @param mutexField A DateTime field on the record to be locked-- this will store the time the lock was acquired, or null if not currently locked
+     */
+    public Mutex(Id recordId, Schema.SObjectField mutexField) {
+
+        Schema.DescribeFieldResult fieldDescribe = mutexField.getDescribe();
+
+        Set<Schema.SObjectField> objectFields = new Set<Schema.SObjectField>(
+            recordId.getSobjectType().getDescribe().fields.getMap().values()
+        );
+
+        Boolean mutexFieldIsDateTime = (Schema.DisplayType.DATETIME == fieldDescribe.getType());
+        Boolean mutexFieldExists = objectFields.contains(mutexField);
+
+        if (!mutexFieldExists || !mutexFieldIsDateTime) {
+            throw new InvalidMutexFieldException(
+                'Mutex expects a valid DateTime field on the given lock record'
+            );
+        }
+
+        if (!fieldDescribe.isUpdateable()) {
+            throw new InvalidMutexFieldException(
+                'User does not have permission to update mutex field'
+            );
+        }
+
+        this.recordId = recordId;
+        this.mutexField = mutexField;
+    }
+
+    /**
+     * @description Construct a query for the record to be locked.
+     *
+     * @param forUpdate True if this query is to include the 'FOR UPDATE' clause-- this should be true if trying to perform an exclusive operation on the record.
+     * @return String The generated SOQL query.
+     */
+    private String getLockQuery(Boolean forUpdate) {
+        String sObjectTypeName = recordId.getSobjectType().getDescribe().getName();
+        String mutexFieldName = mutexField.getDescribe().getName();
+        String forUpdateClause = (forUpdate ? 'FOR UPDATE': '');
+
+        String queryFormat = 'SELECT {0} FROM {1} WHERE Id = \'\'{2}\'\' LIMIT 1 {3}';
+
+        String query = String.format(
+            queryFormat,
+            new List<String>{
+                mutexFieldName,
+                sObjectTypeName,
+                recordId,
+                forUpdateClause
+            }
+        );
+
+        System.debug(queryFormat);
+        System.debug(query);
+
+        return query;
+    }
+
+    /**
+     * @description Queries the database for the record to be locked.  This will return null if the record was unable to be queried (i.e. if it doesn't exist, OR if the FOR UPDATE clause prevented the record from being queried).
+     *
+     * @param forUpdate True if this query is to include the 'FOR UPDATE' clause-- this should be true if trying to perform an exclusive operation on the record.
+     * @return sObject The sObject corresponding to the record to be locked.
+     */
+    @TestVisible
+    private sObject getLockRecord(Boolean forUpdate) {
+        List<sObject> results;
+        try {
+            results = Database.query(getLockQuery(true));
+        } catch (System.DmlException e) {
+            return null;
+        }
+
+        if (results.isEmpty()) {
+            return null;
+        }
+
+        sObject lockRecord = results.get(0);
+        return lockRecord;
+    }
+
+    /**
+     * @description Attempt to acquire a lock.  This will attempt to update the lock record in the database.  This returns true if the lock was able to be acquired, false otherwise.
+     *
+     * @return Boolean
+     */
+    public Boolean acquireLock() {
+        return acquireLock(
+            getLockRecord(true),
+            DateTime.now()
+        );
+    }
+
+    /**
+     * @description Attempt to acquire a lock.  This will attempt to update the lock record in the database.  This returns true if the lock was able to be acquired, false otherwise.
+     *
+     * @param lockRecord The sObject corresponding to the record to be locked (must be queried with the mutexField)
+     * @param lockTime The DateTime of the lock acquire time.  This will be written to the mutexField on the record to be locked.
+     * @return Boolean
+     */
+    @TestVisible
+    private Boolean acquireLock(sObject lockRecord, DateTime lockTime) {
+        if (null == lockRecord) {
+            // can't get a lock on a record that doesn't exist
+            return false;
+        }
+
+        if (null != getLockTime(lockRecord)) {
+            // can't get a lock on a record that is already locked
+            return false;
+        }
+
+        lockRecord.put(mutexField, lockTime);
+        update lockRecord;
+        return true;
+    }
+
+    /*
+     * @description Release the lock that has currently been acquired (if any) on the lock record.  Returns true to indicate that the record is not locked, or false if unable to release lock.
+     *
+     * @return Boolean
+     */
+    public Boolean releaseLock() {
+        return releaseLock(getLockRecord(true));
+    }
+
+    /*
+     * @description Release the lock that has currently been acquired (if any) on the lock record.  Returns true to indicate that the record is not locked, or false if unable to release lock.
+     *
+     * @return Boolean
+     */
+    @TestVisible
+    public Boolean releaseLock(sObject lockRecord) {
+        if (null == lockRecord) {
+            return false;
+        }
+
+        lockRecord.put(mutexField, null);
+        update lockRecord;
+        return true;
+    }
+
+    /*
+     * @description Get the DateTime that a lock was acquired on the record.  Returns null if the record is not locked.
+     *
+     * @return DateTime
+     */
+    public DateTime getLockTime() {
+        return getLockTime(getLockRecord(false));
+    }
+
+    /*
+     * @description Get the DateTime that a lock was acquired on the record.  Returns null if the record is not locked.
+     *
+     * @param lockRecord The sObject corresponding to the record to be locked (must be queried with the mutexField)
+     * @return DateTime
+     */
+    @TestVisible
+    private DateTime getLockTime(sObject lockRecord) {
+        if (null == lockRecord) {
+            return null;
+        }
+        return (DateTime) lockRecord.get(mutexField);
+    }
+
+    public interface MutexInterface {
+        Boolean acquireLock();
+        Boolean releaseLock();
+        DateTime getLockTime();
+    }
+
+    public interface Factory {
+        MutexInterface create(Id recordId, Schema.SObjectField mutexField);
+    }
+
+    public class DefaultFactory implements Factory {
+        public MutexInterface create(Id recordId, Schema.SObjectField mutexField) {
+            return new Mutex(recordId, mutexField);
+        }
+    }
+
+    /*
+     * @description Any exceptions thrown by the Mutex class will extend this class
+     */
+    public virtual class CustomException extends Exception {}
+
+    /*
+     * @description Exception thrown when a valid mutex field is not found on the sObjectType of this Mutex's recordId.
+     */
+    public class InvalidMutexFieldException extends CustomException {}
+}

--- a/src/classes/Mutex.cls
+++ b/src/classes/Mutex.cls
@@ -109,9 +109,6 @@ public with sharing class Mutex implements MutexInterface {
             }
         );
 
-        System.debug(queryFormat);
-        System.debug(query);
-
         return query;
     }
 

--- a/src/classes/Mutex.cls
+++ b/src/classes/Mutex.cls
@@ -52,9 +52,10 @@ public with sharing class Mutex implements MutexInterface {
     public Mutex(Id recordId, Schema.SObjectField mutexField) {
 
         Schema.DescribeFieldResult fieldDescribe = mutexField.getDescribe();
+        Schema.DescribeSObjectResult objectDescribe = recordId.getSObjectType().getDescribe();
 
         Set<Schema.SObjectField> objectFields = new Set<Schema.SObjectField>(
-            recordId.getSobjectType().getDescribe().fields.getMap().values()
+            objectDescribe.fields.getMap().values()
         );
 
         Boolean mutexFieldIsDateTime = (Schema.DisplayType.DATETIME == fieldDescribe.getType());
@@ -62,13 +63,22 @@ public with sharing class Mutex implements MutexInterface {
 
         if (!mutexFieldExists || !mutexFieldIsDateTime) {
             throw new InvalidMutexFieldException(
-                'Mutex expects a valid DateTime field on the given lock record'
+                String.format(
+                    Label.MutexFieldInvalidDateTimeException,
+                    new List<String>{
+                        fieldDescribe.getLabel(),
+                        objectDescribe.getLabel()
+                    }
+                )
             );
         }
 
         if (!fieldDescribe.isUpdateable()) {
             throw new InvalidMutexFieldException(
-                'User does not have permission to update mutex field'
+                String.format(
+                    Label.MutexFieldInvalidUpdateableException,
+                    new List<String>{fieldDescribe.getLabel()}
+                )
             );
         }
 

--- a/src/classes/Mutex.cls-meta.xml
+++ b/src/classes/Mutex.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/Mutex_TEST.cls
+++ b/src/classes/Mutex_TEST.cls
@@ -1,13 +1,13 @@
 @isTest
 private class Mutex_TEST {
     private static testMethod void testConstructorValidField() {
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         Boolean exceptionThrown = false;
 
         try {
-            Mutex campaignMutex = new Mutex(c.Id, Campaign.Campaign_List_Mutex__c);
+            Mutex m = new Mutex(c.Id, Contact.EmailBouncedDate);
         } catch (Exception e) {
             exceptionThrown = true;
         }
@@ -16,13 +16,13 @@ private class Mutex_TEST {
     }
 
     private static testMethod void testConstructorNonModifiableField() {
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         Boolean exceptionThrown = false;
 
         try {
-            Mutex campaignMutex = new Mutex(c.Id, Campaign.SystemModstamp);
+            Mutex m = new Mutex(c.Id, Contact.SystemModstamp);
         } catch (Exception e) {
             exceptionThrown = true;
         }
@@ -31,13 +31,13 @@ private class Mutex_TEST {
     }
 
     private static testMethod void testConstructorNotDateTimeField() {
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         Boolean exceptionThrown = false;
 
         try {
-            Mutex campaignMutex = new Mutex(c.Id, Campaign.Name);
+            Mutex m = new Mutex(c.Id, Contact.Name);
         } catch (Exception e) {
             exceptionThrown = true;
         }
@@ -46,13 +46,13 @@ private class Mutex_TEST {
     }
 
     private static testMethod void testConstructorFieldDoesNotBelongToRecord() {
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         Boolean exceptionThrown = false;
 
         try {
-            Mutex campaignMutex = new Mutex(c.Id, Contact.LastName);
+            Mutex m = new Mutex(c.Id, Opportunity.Amount);
         } catch (Exception e) {
             exceptionThrown = true;
         }
@@ -61,24 +61,24 @@ private class Mutex_TEST {
     }
 
     public static testMethod void testGetLockRecordReturnsNullWhenNoRecordFound() {
-        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+        Id recordId = Contact.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
 
-        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+        Mutex m = new Mutex(recordId, Contact.EmailBouncedDate);
 
         System.assertEquals(null, m.getLockRecord(false));
     }
 
     public static testMethod void testGetLockRecordReturnsCorrectRecord() {
-        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+        Schema.SObjectField mutexField = Contact.EmailBouncedDate;
 
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         Mutex m = new Mutex(c.Id, mutexField);
 
         sObject so = m.getLockRecord(false);
 
-        System.assert(so instanceof Campaign);
+        System.assert(so instanceof Contact);
         System.assertEquals(c.Id, so.Id);
 
         Boolean mutexFieldWasQueried = true;
@@ -93,20 +93,20 @@ private class Mutex_TEST {
     }
 
     public static testMethod void testAcquireLockFailsIfMissingLockRecord() {
-        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+        Id recordId = Contact.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
 
-        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+        Mutex m = new Mutex(recordId, Contact.EmailBouncedDate);
 
         System.assertEquals(false, m.acquireLock(null, null));
     }
 
     public static testMethod void testAcquireLockFailsIfRecordAlreadyLocked() {
-        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+        Schema.SObjectField mutexField = Contact.EmailBouncedDate;
         DateTime lockTime = DateTime.now();
 
-        Campaign c = new Campaign(
-            Name = 'My Test Campaign',
-            Campaign_List_Mutex__c = lockTime
+        Contact c = new Contact(
+            LastName = 'Test Contact',
+            EmailBouncedDate = lockTime
         );
         insert c;
 
@@ -118,9 +118,9 @@ private class Mutex_TEST {
     }
 
     public static testMethod void testAcquireLockUpdatesLockField() {
-        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+        Schema.SObjectField mutexField = Contact.EmailBouncedDate;
 
-        Campaign c = new Campaign(Name = 'My Test Campaign');
+        Contact c = new Contact(LastName = 'Test Contact');
         insert c;
 
         DateTime lockTime = DateTime.now();
@@ -130,8 +130,8 @@ private class Mutex_TEST {
         Boolean lockAcquired = m.acquireLock(c, lockTime);
 
         c = [
-            SELECT Campaign_List_Mutex__c
-            FROM Campaign
+            SELECT EmailBouncedDate
+            FROM Contact
             WHERE Id = :c.Id
         ];
 
@@ -140,24 +140,21 @@ private class Mutex_TEST {
     }
 
     public static testMethod void testReleaseLockReturnsNullIfNoRecord() {
-        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+        Id recordId = Contact.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
 
-        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+        Mutex m = new Mutex(recordId, Contact.EmailBouncedDate);
 
         System.assertEquals(false, m.releaseLock(null));
     }
 
     public static testMethod void testReleaseLockClearsLockField() {
+        Schema.SObjectField mutexField = Contact.EmailBouncedDate;
 
-    }
-
-    public static testMethod void testGetLockTimeReturnsNullIfMissingLockRecord() {
-        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
         DateTime lockTime = DateTime.now();
 
-        Campaign c = new Campaign(
-            Name = 'My Test Campaign',
-            Campaign_List_Mutex__c = lockTime
+        Contact c = new Contact(
+            LastName = 'Test Contact',
+            EmailBouncedDate = lockTime
         );
         insert c;
 
@@ -166,8 +163,32 @@ private class Mutex_TEST {
         Boolean lockReleased = m.releaseLock(c);
 
         c = [
-            SELECT Campaign_List_Mutex__c
-            FROM Campaign
+            SELECT EmailBouncedDate
+            FROM Contact
+            WHERE Id = :c.Id
+        ];
+
+        System.assert(lockReleased);
+        System.assertEquals(null, c.get(mutexField));
+    }
+
+    public static testMethod void testGetLockTimeReturnsNullIfMissingLockRecord() {
+        Schema.SObjectField mutexField = Contact.EmailBouncedDate;
+        DateTime lockTime = DateTime.now();
+
+        Contact c = new Contact(
+            LastName = 'Test Contact',
+            EmailBouncedDate = lockTime
+        );
+        insert c;
+
+        Mutex m = new Mutex(c.Id, mutexField);
+
+        Boolean lockReleased = m.releaseLock(c);
+
+        c = [
+            SELECT EmailBouncedDate
+            FROM Contact
             WHERE Id = :c.Id
         ];
 
@@ -176,11 +197,11 @@ private class Mutex_TEST {
     }
 
     public static testMethod void testGetLockTimeReturnsLockTime() {
-        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+        Id recordId = Contact.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
         DateTime lockTime = DateTime.now();
-        Campaign c = new Campaign(Campaign_List_Mutex__c = lockTime);
+        Contact c = new Contact(EmailBouncedDate = lockTime);
 
-        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+        Mutex m = new Mutex(recordId, Contact.EmailBouncedDate);
 
         System.assertEquals(lockTime, m.getLockTime(c));
     }

--- a/src/classes/Mutex_TEST.cls
+++ b/src/classes/Mutex_TEST.cls
@@ -1,0 +1,187 @@
+@isTest
+private class Mutex_TEST {
+    private static testMethod void testConstructorValidField() {
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        Boolean exceptionThrown = false;
+
+        try {
+            Mutex campaignMutex = new Mutex(c.Id, Campaign.Campaign_List_Mutex__c);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+
+        System.assert(!exceptionThrown);
+    }
+
+    private static testMethod void testConstructorNonModifiableField() {
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        Boolean exceptionThrown = false;
+
+        try {
+            Mutex campaignMutex = new Mutex(c.Id, Campaign.SystemModstamp);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+
+        System.assert(exceptionThrown);
+    }
+
+    private static testMethod void testConstructorNotDateTimeField() {
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        Boolean exceptionThrown = false;
+
+        try {
+            Mutex campaignMutex = new Mutex(c.Id, Campaign.Name);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+
+        System.assert(exceptionThrown);
+    }
+
+    private static testMethod void testConstructorFieldDoesNotBelongToRecord() {
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        Boolean exceptionThrown = false;
+
+        try {
+            Mutex campaignMutex = new Mutex(c.Id, Contact.LastName);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+
+        System.assert(exceptionThrown);
+    }
+
+    public static testMethod void testGetLockRecordReturnsNullWhenNoRecordFound() {
+        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+
+        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+
+        System.assertEquals(null, m.getLockRecord(false));
+    }
+
+    public static testMethod void testGetLockRecordReturnsCorrectRecord() {
+        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        Mutex m = new Mutex(c.Id, mutexField);
+
+        sObject so = m.getLockRecord(false);
+
+        System.assert(so instanceof Campaign);
+        System.assertEquals(c.Id, so.Id);
+
+        Boolean mutexFieldWasQueried = true;
+
+        try {
+            so.get(mutexField);
+        } catch (SObjectException e) {
+            mutexFieldWasQueried = false;
+        }
+
+        System.assert(mutexFieldWasQueried);
+    }
+
+    public static testMethod void testAcquireLockFailsIfMissingLockRecord() {
+        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+
+        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+
+        System.assertEquals(false, m.acquireLock(null, null));
+    }
+
+    public static testMethod void testAcquireLockFailsIfRecordAlreadyLocked() {
+        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+        DateTime lockTime = DateTime.now();
+
+        Campaign c = new Campaign(
+            Name = 'My Test Campaign',
+            Campaign_List_Mutex__c = lockTime
+        );
+        insert c;
+
+        Mutex m = new Mutex(c.Id, mutexField);
+
+        Boolean lockAcquired = m.acquireLock(c, lockTime);
+
+        System.assertEquals(false, lockAcquired);
+    }
+
+    public static testMethod void testAcquireLockUpdatesLockField() {
+        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+
+        Campaign c = new Campaign(Name = 'My Test Campaign');
+        insert c;
+
+        DateTime lockTime = DateTime.now();
+
+        Mutex m = new Mutex(c.Id, mutexField);
+
+        Boolean lockAcquired = m.acquireLock(c, lockTime);
+
+        c = [
+            SELECT Campaign_List_Mutex__c
+            FROM Campaign
+            WHERE Id = :c.Id
+        ];
+
+        System.assert(lockAcquired);
+        System.assertEquals(lockTime, c.get(mutexField));
+    }
+
+    public static testMethod void testReleaseLockReturnsNullIfNoRecord() {
+        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+
+        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+
+        System.assertEquals(false, m.releaseLock(null));
+    }
+
+    public static testMethod void testReleaseLockClearsLockField() {
+
+    }
+
+    public static testMethod void testGetLockTimeReturnsNullIfMissingLockRecord() {
+        Schema.SObjectField mutexField = Campaign.Campaign_List_Mutex__c;
+        DateTime lockTime = DateTime.now();
+
+        Campaign c = new Campaign(
+            Name = 'My Test Campaign',
+            Campaign_List_Mutex__c = lockTime
+        );
+        insert c;
+
+        Mutex m = new Mutex(c.Id, mutexField);
+
+        Boolean lockReleased = m.releaseLock(c);
+
+        c = [
+            SELECT Campaign_List_Mutex__c
+            FROM Campaign
+            WHERE Id = :c.Id
+        ];
+
+        System.assert(lockReleased);
+        System.assertEquals(null, c.get(mutexField));
+    }
+
+    public static testMethod void testGetLockTimeReturnsLockTime() {
+        Id recordId = Campaign.sObjectType.getDescribe().getKeyPrefix() + '000000000000';
+        DateTime lockTime = DateTime.now();
+        Campaign c = new Campaign(Campaign_List_Mutex__c = lockTime);
+
+        Mutex m = new Mutex(recordId, Campaign.Campaign_List_Mutex__c);
+
+        System.assertEquals(lockTime, m.getLockTime(c));
+    }
+}

--- a/src/classes/Mutex_TEST.cls-meta.xml
+++ b/src/classes/Mutex_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ProcessSegmentBTN_CTRL.cls
+++ b/src/classes/ProcessSegmentBTN_CTRL.cls
@@ -71,7 +71,10 @@ public with sharing class ProcessSegmentBTN_CTRL {
         } catch (CampaignListService.CampaignListUpdateAlreadyRunningException e) {
             ApexPages.addMessage(new ApexPages.Message(
                 ApexPages.Severity.ERROR,
-                'Unable to refresh campaign because another campaign list update is already in progress.'
+                String.format(
+                    Label.CampaignToolsAlreadyRunningException,
+                    new List<String>{campaign.Name}
+                )
             ));
             return null;
         }

--- a/src/classes/ProcessSegmentBTN_CTRL.cls
+++ b/src/classes/ProcessSegmentBTN_CTRL.cls
@@ -62,10 +62,20 @@ public with sharing class ProcessSegmentBTN_CTRL {
         }
         
         CampaignList.Service service = CampaignList.getService();
-        service.updateCampaignFromCampaignList(campaign.Id, campaign.Campaign_List__c);
         
-        // return back to the campaign.
-        return pgRet;
+        try {
+            service.updateCampaignFromCampaignList(campaign.Id, campaign.Campaign_List__c);
+
+            // return back to the campaign.
+            return pgRet;
+        } catch (CampaignListService.CampaignListUpdateAlreadyRunningException e) {
+            ApexPages.addMessage(new ApexPages.Message(
+                ApexPages.Severity.ERROR,
+                'Unable to refresh campaign because another campaign list update is already in progress.'
+            ));
+            return null;
+        }
+
     }
 
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1,19 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
     <labels>
-        <fullName>logicAND</fullName>
-        <categories>logic</categories>
+        <fullName>CampaignToolsAlreadyRunningException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
         <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>logicAND</shortDescription>
-        <value>AND</value>
+        <protected>true</protected>
+        <shortDescription>CampaignToolsAlreadyRunningException</shortDescription>
+        <value>Could not update campaign {0} because this campaign is locked by another campaign list update.</value>
     </labels>
     <labels>
-        <fullName>logicOR</fullName>
-        <categories>logic</categories>
+        <fullName>CampaignToolsCantFinishUpdateException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
         <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>logicOR</shortDescription>
-        <value>OR</value>
+        <protected>true</protected>
+        <shortDescription>CampaignToolsCantFinishUpdateException</shortDescription>
+        <value>Could not finish updating campaign {0}</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsCantUpdateException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>CampaignToolsCantUpdateException</shortDescription>
+        <value>Could not update campaign {0}.</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsReleaseLockException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>CampaignToolsReleaseLockException</shortDescription>
+        <value>Could not release lock on campaign {0}</value>
+    </labels>
+    <labels>
+        <fullName>MutexFieldInvalidDateTimeException</fullName>
+        <categories>Mutex,Exceptions</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>MutexFieldInvalidDateTimeException</shortDescription>
+        <value>Mutex requires {0} to be a valid DateTime field on the {1} object</value>
+    </labels>
+    <labels>
+        <fullName>MutexFieldInvalidUpdateableException</fullName>
+        <categories>Mutex,Exceptions</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>MutexFieldInvalidUpdateableException</shortDescription>
+        <value>User does not have permission to update the mutex field, {0}</value>
+    </labels>
+    <labels>
+        <fullName>ReturnToCampaign</fullName>
+        <categories>CampaignTools</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>ReturnToCampaign</shortDescription>
+        <value>Return to Campaign</value>
     </labels>
 </CustomLabels>

--- a/src/objects/Campaign.object
+++ b/src/objects/Campaign.object
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
+        <fullName>Campaign_List_Last_Updated__c</fullName>
+        <description>This contains the date/time of when this Campaign was last successfully populated by a Campaign List</description>
+        <externalId>false</externalId>
+        <label>Campaign List Last Updated</label>
+        <required>false</required>
+        <type>DateTime</type>
+    </fields>
+    <fields>
+        <fullName>Campaign_List_Mutex__c</fullName>
+        <description>This field indicates whether a mutex/lock is placed on this Campaign object.  A time value in this field indicates that a lock is in place, and the time when the lock was placed.  A null value in this field indicates no lock is being held.  This field must be updated atomically to avoid concurrency issues.</description>
+        <externalId>false</externalId>
+        <label>Campaign List Mutex</label>
+        <required>false</required>
+        <type>DateTime</type>
+    </fields>
+    <fields>
         <fullName>Campaign_List_Update_Status__c</fullName>
         <description>This tracks the status of updating this Campaign from a campaign list</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -84,12 +84,18 @@
         <name>CustomField</name>
     </types>
     <types>
-        <members>logicAND</members>
-        <members>logicOR</members>
+        <members>CampaignToolsAlreadyRunningException</members>
+        <members>CampaignToolsCantFinishUpdateException</members>
+        <members>CampaignToolsCantUpdateException</members>
+        <members>CampaignToolsReleaseLockException</members>
+        <members>MutexFieldInvalidDateTimeException</members>
+        <members>MutexFieldInvalidUpdateableException</members>
+        <members>ReturnToCampaign</members>
         <name>CustomLabel</name>
     </types>
     <types>
-        <name>CustomLabel</name>
+        <members>CustomLabels</members>
+        <name>CustomLabels</name>
     </types>
     <types>
         <members>Campaign</members>
@@ -119,5 +125,5 @@
         <members>Campaign.Refresh_Campaign_List</members>
         <name>WebLink</name>
     </types>
-    <version>34.0</version>
+    <version>35.0</version>
 </Package>

--- a/src/package.xml
+++ b/src/package.xml
@@ -31,6 +31,8 @@
         <members>DeleteCampaignListMembersBatch_TEST</members>
         <members>DeleteCampaignMembersBatch</members>
         <members>DeleteCampaignMembersBatch_TEST</members>
+        <members>Mutex</members>
+        <members>Mutex_TEST</members>
         <members>ProcessSegmentBTN_CTRL</members>
         <members>ProcessSegmentBTN_TEST</members>
         <members>ReportService</members>
@@ -61,6 +63,8 @@
         <name>AuraDefinitionBundle</name>
     </types>
     <types>
+        <members>Campaign.Campaign_List_Last_Updated__c</members>
+        <members>Campaign.Campaign_List_Mutex__c</members>
         <members>Campaign.Campaign_List_Update_Status__c</members>
         <members>Campaign.Campaign_List__c</members>
         <members>CampaignMember.Source_Names__c</members>

--- a/src/pages/ProcessSegmentBTN.page
+++ b/src/pages/ProcessSegmentBTN.page
@@ -1,5 +1,5 @@
 <apex:page standardController="Campaign" extensions="ProcessSegmentBTN_CTRL" action="{!refreshCampaignList}" >
     <apex:outputText value="{!Campaign.Campaign_List__c}" rendered="false"/>
     <apex:PageMessages />
-    <apex:outputLink value="{!URLFOR($Action.Campaign.View, Campaign.Id)}">Return to Campaign</apex:outputLink>
+    <apex:outputLink value="{!URLFOR($Action.Campaign.View, Campaign.Id)}">{!$Label.ReturnToCampaign}</apex:outputLink>
 </apex:page>

--- a/src/pages/ProcessSegmentBTN.page
+++ b/src/pages/ProcessSegmentBTN.page
@@ -1,4 +1,5 @@
 <apex:page standardController="Campaign" extensions="ProcessSegmentBTN_CTRL" action="{!refreshCampaignList}" >
+    <apex:outputText value="{!Campaign.Name}" rendered="false"/>
     <apex:outputText value="{!Campaign.Campaign_List__c}" rendered="false"/>
     <apex:PageMessages />
     <apex:outputLink value="{!URLFOR($Action.Campaign.View, Campaign.Id)}">{!$Label.ReturnToCampaign}</apex:outputLink>

--- a/src/pages/ProcessSegmentBTN.page
+++ b/src/pages/ProcessSegmentBTN.page
@@ -1,4 +1,5 @@
 <apex:page standardController="Campaign" extensions="ProcessSegmentBTN_CTRL" action="{!refreshCampaignList}" >
     <apex:outputText value="{!Campaign.Campaign_List__c}" rendered="false"/>
     <apex:PageMessages />
+    <apex:outputLink value="{!URLFOR($Action.Campaign.View, Campaign.Id)}">Return to Campaign</apex:outputLink>
 </apex:page>


### PR DESCRIPTION
Adding Campaign_List_Last_Updated__c timestamp field to Campaign object that gets updated after successful completion of a campaign list update process.

Adding new Mutex class, for better concurrency control.

Mutex lock is acquired before starting campaign list update process (in CampaignListService) and released after successful completion of campaign list update process (in CampaignListToCampaignBatch.finish()).

Adding error message to "Campaign Refresh List" button to indicate to user if an existing campaign list process is running.