### PR TITLE
Add error trapping to Campaign Tools batches

### DIFF
--- a/src/classes/CampaignList.cls
+++ b/src/classes/CampaignList.cls
@@ -39,8 +39,11 @@ public abstract class CampaignList {
         void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId);
         void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId, Boolean acquireLock);
         void updateCampaignStatus(Id campaignId, UpdateStatus status);
+        void unlockCampaignAndMarkFailed(Id campaignId, String errorMessage);
         Integer getFlexQueueCapacity(Integer maxFreeSlots);
         Id enqueueJob(Queueable job);
+        Id getJobId(Database.BatchableContext bc);
+        void abortJob(Id jobId);
     }
 
     public interface ReportService {

--- a/src/classes/CampaignListFromCampaignBatch.cls
+++ b/src/classes/CampaignListFromCampaignBatch.cls
@@ -42,31 +42,39 @@ public class CampaignListFromCampaignBatch extends BatchableSequence.Batch imple
     private Id rootSegmentId;
 
     /**
+     * @description The id of the Campaign being refreshed
+     */
+    @TestVisible
+    private Id targetCampaignId;
+
+    /**
      * @description The id of the Campaign from which to gather potential
      * members
      */
     @TestVisible
-    private Id campaignId;
+    private Id sourceCampaignId;
 
     /**
      * @description The name of the Campaign from which to gather potential
      * members
      */
     @TestVisible
-    private String campaignName;
+    private String sourceCampaignName;
 
     /**
      * @description Construct the batch process to gather potential members
      * from a given campaign for a given campaign list.
      *
      * @param rootSegmentId The id of the "campaign list" which the members should be added to
-     * @param campaignId The id of the Campaign from which to gather potential members
-     * @param campaignName The name of the Campaign from which to gather potential members
+     * @param targetCampaignId The id of the Campaign being refreshed
+     * @param sourceCampaignId The id of the Campaign from which to gather potential members
+     * @param sourceCampaignName The name of the Campaign from which to gather potential members
      */
-    public CampaignListFromCampaignBatch(Id rootSegmentId, Id campaignId, String campaignName) {
+    public CampaignListFromCampaignBatch(Id rootSegmentId, Id targetCampaignId, Id sourceCampaignId, String sourceCampaignName) {
         this.rootSegmentId = rootSegmentId;
-        this.campaignId = campaignId;
-        this.campaignName = campaignName;
+        this.targetCampaignId = targetCampaignId;
+        this.sourceCampaignId = sourceCampaignId;
+        this.sourceCampaignName = sourceCampaignName;
     }
 
     /**
@@ -77,7 +85,7 @@ public class CampaignListFromCampaignBatch extends BatchableSequence.Batch imple
      */
     public Database.QueryLocator start(Database.BatchableContext bc) {
         return Database.getQueryLocator(
-            'SELECT ContactId, LeadId FROM CampaignMember WHERE CampaignId = :campaignId'
+            'SELECT ContactId, LeadId FROM CampaignMember WHERE CampaignId = :sourceCampaignId'
         );
     }
 
@@ -90,23 +98,38 @@ public class CampaignListFromCampaignBatch extends BatchableSequence.Batch imple
      * @return void
      */
     public void execute(Database.BatchableContext bc, List<CampaignMember> campaignMembers) {
-        Set<Id> ids = new Set<Id>();
+        try {
+            Set<Id> ids = new Set<Id>();
 
-        for (CampaignMember cm : campaignMembers) {
-            if (null != cm.ContactId) {
-                ids.add(cm.ContactId);
+            for (CampaignMember cm : campaignMembers) {
+                if (null != cm.ContactId) {
+                    ids.add(cm.ContactId);
+                }
+                if (null != cm.LeadId) {
+                    ids.add(cm.LeadId);
+                }
             }
-            if (null != cm.LeadId) {
-                ids.add(cm.LeadId);
-            }
+
+            CampaignList.getMemberMapper().updateByRelatedIdsAndSource(
+                new List<Id>(ids),
+                rootSegmentId,
+                sourceCampaignId,
+                sourceCampaignName
+            );
+        } catch (Exception e) {
+            CampaignList.Service service = CampaignList.getService();
+            service.unlockCampaignAndMarkFailed(
+                targetCampaignId,
+                String.format(
+                    Label.CampaignToolsListFromCampaignExecuteException,
+                    new List<String>{
+                        sourceCampaignId,
+                        rootSegmentId
+                    }
+                )
+            );
+            service.abortJob(service.getJobId(bc));
         }
-
-        CampaignList.getMemberMapper().updateByRelatedIdsAndSource(
-            new List<Id>(ids),
-            rootSegmentId,
-            campaignId,
-            campaignName
-        );
     }
 
     /**

--- a/src/classes/CampaignListFromCampaignBatch_TEST.cls
+++ b/src/classes/CampaignListFromCampaignBatch_TEST.cls
@@ -31,11 +31,13 @@
 private class CampaignListFromCampaignBatch_TEST {
     private static testMethod void testCampaignListFromCampaignBatch() {
         Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id targetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
         CampaignList_TEST.TestCampaign testCampaign = new CampaignList_TEST.TestCampaign('Test', 100, 100);
 
         CampaignListFromCampaignBatch batch = new CampaignListFromCampaignBatch(
             rootSegmentId,
+            targetCampaignId,
             testCampaign.campaign.Id,
             testCampaign.campaign.Name
         );
@@ -56,17 +58,82 @@ private class CampaignListFromCampaignBatch_TEST {
         for (Contact c : testCampaign.contacts) {
             relatedIds.add(c.Id);
         }
+
         for (Lead l : testCampaign.leads) {
             relatedIds.add(l.Id);
         }
 
         System.assertEquals(
             relatedIds,
-            new Set<Id>(memberMapperStub.relatedIds)
+            new Set<Id>(memberMapperStub.updateByRelatedIdsAndSourceRelatedIds)
         );
 
-        System.assertEquals(rootSegmentId, memberMapperStub.rootSegmentId);
-        System.assertEquals(testCampaign.campaign.Id, memberMapperStub.sourceId);
-        System.assertEquals(testCampaign.campaign.Name, memberMapperStub.sourceName);
+        System.assertEquals(
+            rootSegmentId,
+            memberMapperStub.updateByRelatedIdsAndSourceRootSegmentId
+        );
+
+        System.assertEquals(
+            testCampaign.campaign.Id,
+            memberMapperStub.updateByRelatedIdsAndSourceSourceId
+        );
+
+        System.assertEquals(
+            testCampaign.campaign.Name,
+            memberMapperStub.updateByRelatedIdsAndSourceSourceName
+        );
+    }
+
+    private static testMethod void testCampaignListFromCampaignBatchHandlesException() {
+        CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
+        CampaignList_TEST.MemberMapperStub memberMapperStub = new CampaignList_TEST.MemberMapperStub();
+
+        memberMapperStub.updateByRelatedIdsAndSourceException = new CampaignList_TEST.MockException();
+
+        Id jobId = CampaignList_TEST.getNextId(AsyncApexJob.sObjectType);
+        serviceStub.getJobIdReturn = jobId;
+
+        CampaignList.setService(serviceStub);
+        CampaignList.setMemberMapper(memberMapperStub);
+
+        Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id targetCampaignId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id sourceCampaignId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        String sourceCampaignName = 'Test Source Campaign';
+
+        CampaignListFromCampaignBatch batch = new CampaignListFromCampaignBatch(
+            rootSegmentId,
+            targetCampaignId,
+            sourceCampaignId,
+            sourceCampaignName
+        );
+
+        Test.startTest();
+
+        batch.execute(null, new List<CampaignMember>());
+
+        Test.stopTest();
+
+        System.assertEquals(
+            targetCampaignId,
+            serviceStub.unlockCampaignAndMarkFailedCampaignId
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                sourceCampaignId
+            )
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                rootSegmentId
+            )
+        );
+
+        System.assertEquals(
+            jobId,
+            serviceStub.abortJobJobId
+        );
     }
 }

--- a/src/classes/CampaignListFromReportBatch.cls
+++ b/src/classes/CampaignListFromReportBatch.cls
@@ -42,6 +42,12 @@ public class CampaignListFromReportBatch extends BatchableSequence.Batch impleme
     private Id rootSegmentId;
 
     /**
+     * @description The id of the Campaign to be refreshed
+     */
+    @TestVisible
+    private Id targetCampaignId;
+
+    /**
      * @description The id of the Report from which to gather potential
      * members
      */
@@ -63,41 +69,56 @@ public class CampaignListFromReportBatch extends BatchableSequence.Batch impleme
     private String reportName;
 
     /**
-     * @description
+     * @description A factory for generating an Id iterable
      */
     @TestVisible
-    private Iterable<Id> idIterator;
+    private IdIterableFactory idIterableFactory = new DefaultIdIterableFactory();
 
     /**
      * @description Construct the batch process to gather potential members
      * from a given report for a given campaign list.
      *
      * @param rootSegmentId The id of the "campaign list" which the members should be added to
+     * @param targetCampaignId The id of the Campaign to be refreshed
      * @param reportId The id of the Report from which to gather potential members
      * @param idColumnName The name of the column in the report to retrieve id values from
      * @param reportName The name of the Report from which to gather potential members
      */
-    public CampaignListFromReportBatch(Id rootSegmentId, Id reportId, String idColumnName, String reportName) {
+    public CampaignListFromReportBatch(Id rootSegmentId, Id targetCampaignId, Id reportId, String idColumnName, String reportName) {
         this.rootSegmentId = rootSegmentId;
+        this.targetCampaignId = targetCampaignId;
         this.reportId = reportId;
         this.idColumnName = idColumnName;
         this.reportName = reportName;
     }
 
     /**
-     * @description Get the iterator that will provide ids to the execute()
-     * method.  If an iterable is already specified for this batch, it will be
-     * used.  Otherwise, an instance of the default implementation,
-     * ReportService.ReportRowValueIterableIterator, will be used.
-     *
-     * @return Iterable<Id>
+     * @description A factory for generating an Id iterable
+     */
+    public interface IdIterableFactory {
+        Iterable<Id> create(Id reportId, String idColumnName);
+    }
+
+    /**
+     * @description A default implementation of a factory for generating an Id
+     * iterable.  This will create a ReportService.ReportRowIdIterableIterator.
      */
     @TestVisible
-    private Iterable<Id> getIdIterable() {
-        if (null == idIterator) {
-            idIterator = new ReportService.ReportRowIdIterableIterator(reportId, idColumnName);
+    private class DefaultIdIterableFactory implements IdIterableFactory {
+        /**
+         * @description Create a ReportService.ReportRowIdIterableIterator
+         * using the given parameters.
+         *
+         * @param reportId The id of the report to iterate over
+         * @param idColumnName The name of the column in the report to return from the iterator
+         * @return Iterable<Id>
+         */
+        public Iterable<Id> create(Id reportId, String idColumnName) {
+            return new ReportService.ReportRowIdIterableIterator(
+                reportId,
+                idColumnName
+            );
         }
-        return idIterator;
     }
 
     /**
@@ -107,7 +128,23 @@ public class CampaignListFromReportBatch extends BatchableSequence.Batch impleme
      * @return Iterable<Id> An iterable that will provide values from the id column of the given report
      */
     public Iterable<Id> start(Database.BatchableContext bc) {
-        return getIdIterable();
+        try {
+            return idIterableFactory.create(reportId, idColumnName);
+        } catch (Exception e) {
+            CampaignList.Service service = CampaignList.getService();
+            service.unlockCampaignAndMarkFailed(
+                targetCampaignId,
+                String.format(
+                    Label.CampaignToolsListFromReportStartException,
+                    new List<String>{
+                        reportId,
+                        rootSegmentId
+                    }
+                )
+            );
+            service.abortJob(service.getJobId(bc));
+            return null;
+        }
     }
 
     /**
@@ -119,12 +156,27 @@ public class CampaignListFromReportBatch extends BatchableSequence.Batch impleme
      * @return void
      */
     public void execute(Database.BatchableContext bc, List<Id> ids) {
-        CampaignList.getMemberMapper().updateByRelatedIdsAndSource(
-            ids,
-            rootSegmentId,
-            reportId,
-            reportName
-        );
+        try {
+            CampaignList.getMemberMapper().updateByRelatedIdsAndSource(
+                ids,
+                rootSegmentId,
+                reportId,
+                reportName
+            );
+        } catch (Exception e) {
+            CampaignList.Service service = CampaignList.getService();
+            service.unlockCampaignAndMarkFailed(
+                targetCampaignId,
+                String.format(
+                    Label.CampaignToolsListFromReportExecuteException,
+                    new List<String>{
+                        reportId,
+                        rootSegmentId
+                    }
+                )
+            );
+            service.abortJob(service.getJobId(bc));
+        }
     }
 
     /**

--- a/src/classes/CampaignListFromReportBatch_TEST.cls
+++ b/src/classes/CampaignListFromReportBatch_TEST.cls
@@ -29,62 +29,32 @@
 */
 @isTest
 private class CampaignListFromReportBatch_TEST {
-    private static testMethod void testGetValueIteratorReturnsPresetIterable() {
-        List<Id> testIterable = new List<Id>{
-            CampaignList_TEST.getNextId(Contact.sObjectType)
-        };
-
-        CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
-            CampaignList_TEST.getNextId(Segment__c.sObjectType),
-            CampaignList_TEST.getNextId(Report.sObjectType),
-            'Test_Column_Name',
-            'Test Source Name'
-        );
-
-        batch.idIterator = testIterable;
-
-        System.assertEquals(testIterable, batch.getIdIterable());
-    }
-
-    private static testMethod void testGetValueIteratorReturnsDefaultIterable() {
-        Id testRootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
-        Id testReportId = CampaignList_TEST.getNextId(Report.sObjectType);
-        CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
-            testRootSegmentId,
-            testReportId,
-            'Test_Column_Name',
-            'Test Source Name'
-        );
-
-        ReportService.ReportRowIdIterableIterator actualIterator = (ReportService.ReportRowIdIterableIterator) batch.getIdIterable();
-
-        System.assertNotEquals(null, actualIterator);
-        System.assertEquals(testReportId, actualIterator.reportId);
-        System.assertEquals('Test_Column_Name', actualIterator.columnName);
-    }
-
     private static testMethod void testCampaignListFromReportBatchProcessesIdsFromIterable() {
         Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id testTargetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
         Id sourceId = CampaignList_TEST.getNextId(Report.sObjectType);
         String sourceName = 'Test';
 
         CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
             rootSegmentId,
+            testTargetCampaignId,
             sourceId,
             'Test_Column_Name',
             sourceName
         );
-        
+
         List<Id> relatedIds = new List<Id>();
-        
+
         for (Integer i = 1; i <= 200; i++) {
             relatedIds.add(CampaignList_TEST.getNextId(Contact.sObjectType));
         }
-        
-        batch.idIterator = relatedIds;
-        
+
+        IdIterableFactoryStub factoryStub = new IdIterableFactoryStub();
+        factoryStub.createReturn = relatedIds;
+        batch.idIterableFactory = factoryStub;
+
         CampaignList_TEST.MemberMapperStub listMemberStub = new CampaignList_TEST.MemberMapperStub();
-        CampaignList.setMemberMapper(listMemberStub);                
+        CampaignList.setMemberMapper(listMemberStub);
 
         batch.setScope(200);
 
@@ -93,10 +63,123 @@ private class CampaignListFromReportBatch_TEST {
         batch.executeBatch();
 
         Test.stopTest();
-        
-        System.assertEquals(relatedIds, listMemberStub.relatedIds);
-        System.assertEquals(rootSegmentId, listMemberStub.rootSegmentId);
-        System.assertEquals(sourceId, listMemberStub.sourceId);
-        System.assertEquals(sourceName, listMemberStub.sourceName);
+
+        System.assertEquals(relatedIds, listMemberStub.updateByRelatedIdsAndSourceRelatedIds);
+        System.assertEquals(rootSegmentId, listMemberStub.updateByRelatedIdsAndSourceRootSegmentId);
+        System.assertEquals(sourceId, listMemberStub.updateByRelatedIdsAndSourceSourceId);
+        System.assertEquals(sourceName, listMemberStub.updateByRelatedIdsAndSourceSourceName);
+    }
+
+    private static testMethod void testStartHandlesException() {
+        Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id testTargetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id sourceId = CampaignList_TEST.getNextId(Report.sObjectType);
+        String sourceName = 'Test';
+        Id jobId = CampaignList_TEST.getNextId(AsyncApexJob.sObjectType);
+
+        CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
+            rootSegmentId,
+            testTargetCampaignId,
+            sourceId,
+            'Test_Column_Name',
+            sourceName
+        );
+
+        IdIterableFactoryStub factoryStub = new IdIterableFactoryStub();
+        factoryStub.createException = new CampaignList_TEST.MockException();
+        batch.idIterableFactory = factoryStub;
+
+        CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
+
+        serviceStub.getJobIdReturn = jobId;
+        CampaignList.setService(serviceStub);
+
+        batch.start(null);
+
+        System.assertEquals(
+            testTargetCampaignId,
+            serviceStub.unlockCampaignAndMarkFailedCampaignId
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                sourceId
+            )
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                rootSegmentId
+            )
+        );
+
+        System.assertEquals(
+            jobId,
+            serviceStub.abortJobJobId
+        );
+    }
+
+    private static testMethod void testExecuteHandlesException() {
+        Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id testTargetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id sourceId = CampaignList_TEST.getNextId(Report.sObjectType);
+        String sourceName = 'Test';
+        Id jobId = CampaignList_TEST.getNextId(AsyncApexJob.sObjectType);
+
+        CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
+            rootSegmentId,
+            testTargetCampaignId,
+            sourceId,
+            'Test_Column_Name',
+            sourceName
+        );
+
+        CampaignList_TEST.MemberMapperStub memberMapperStub = new CampaignList_TEST.MemberMapperStub();
+        memberMapperStub.updateByRelatedIdsAndSourceException = new CampaignList_TEST.MockException();
+        CampaignList.setMemberMapper(memberMapperStub);
+
+        CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
+        serviceStub.getJobIdReturn = jobId;
+        CampaignList.setService(serviceStub);
+
+        batch.execute(null, new List<Id>());
+
+        System.assertEquals(
+            testTargetCampaignId,
+            serviceStub.unlockCampaignAndMarkFailedCampaignId
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                sourceId
+            )
+        );
+
+        System.assert(
+            serviceStub.unlockCampaignAndMarkFailedErrorMessage.contains(
+                rootSegmentId
+            )
+        );
+
+        System.assertEquals(
+            jobId,
+            serviceStub.abortJobJobId
+        );
+    }
+
+    private class IdIterableFactoryStub implements CampaignListFromReportBatch.IdIterableFactory {
+        public Id createReportId;
+        public String createIdColumnName;
+        public Iterable<Id> createReturn;
+        public Exception createException;
+        public Iterable<Id> create(Id reportId, String idColumnName) {
+            this.createReportId = reportId;
+            this.createIdColumnName = idColumnName;
+            if (null != this.createException) {
+                throw this.createException;
+            } else {
+                return this.createReturn;
+            }
+        }
     }
 }

--- a/src/classes/CampaignListRefreshSchedulable_TEST.cls
+++ b/src/classes/CampaignListRefreshSchedulable_TEST.cls
@@ -678,8 +678,8 @@ private class CampaignListRefreshSchedulable_TEST {
         CampaignListRefreshSchedulable.CampaignGraph cg = new CampaignListRefreshSchedulable.CampaignGraph();
         cg.nodes = tn.nodes;
 
-        CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
-        serviceStub.flexQueueCapacity = 10;
+        ServiceStubUpdateList serviceStub = new ServiceStubUpdateList();
+        serviceStub.getFlexQueueCapacityReturn = 10;
         CampaignList.setService(serviceStub);
 
         CampaignListRefreshSchedulable.Worker w = new CampaignListRefreshSchedulable.Worker(cg);
@@ -690,40 +690,16 @@ private class CampaignListRefreshSchedulable_TEST {
 
         Test.stopTest();
 
-        System.assertEquals(50, serviceStub.maxFreeSlots);
-
-        System.assertEquals(2, serviceStub.updateCampaignIdList.size());
-        System.assertEquals(2, serviceStub.updateRootSegmentIdList.size());
-        System.assertEquals(2, serviceStub.updateCampaignFromCampaignListAcquireLockList.size());
-
-        Set<Id> expectedReadySet = new Set<Id>{
-            tn.campaignId1,
-            tn.campaignId3
+        Set<UpdateCall> expectedCalls = new Set<UpdateCall>{
+            new UpdateCall(tn.campaignId1, tn.cn1.campaignListId, false),
+            new UpdateCall(tn.campaignId3, tn.cn3.campaignListId, false)
         };
 
-        Set<Id> expectedRootSegmentIdSet = new Set<Id>{
-            tn.cn1.campaignListId,
-            tn.cn3.campaignListId
-        };
+        Set<UpdateCall> actualCalls = new Set<UpdateCall>(serviceStub.calls);
 
-        for (Integer i = 0; i < 2; i++) {
-            System.assert(
-                expectedReadySet.contains(
-                    serviceStub.updateCampaignIdList.get(i)
-                )
-            );
-
-            System.assert(
-                expectedRootSegmentIdSet.contains(
-                    serviceStub.updateRootSegmentIdList.get(i)
-                )
-            );
-
-            System.assertEquals(
-                false,
-                serviceStub.updateCampaignFromCampaignListAcquireLockList.get(i)
-            );
-        }
+        System.assertEquals(50, serviceStub.getFlexQueueCapacityMaxFreeSlots);
+        System.assertEquals(2, serviceStub.calls.size());
+        System.assertEquals(expectedCalls, actualCalls);
 
         CampaignListRefreshSchedulable.Worker nextWorker = (CampaignListRefreshSchedulable.Worker) serviceStub.enqueueJobJob;
 
@@ -731,6 +707,40 @@ private class CampaignListRefreshSchedulable_TEST {
             w.cg,
             nextWorker.cg
         );
+    }
+
+    private class UpdateCall {
+        public Id campaignId;
+        public Id rootSegmentId;
+        public Boolean acquireLock;
+        public UpdateCall(Id campaignId, Id rootSegmentId, Boolean acquireLock) {
+            this.campaignId = campaignId;
+            this.rootSegmentId = rootSegmentId;
+            this.acquireLock = acquireLock;
+        }
+        public Integer hashCode() {
+            System.debug('in hashcode');
+            System.debug(this);
+            return ((Object) campaignId).hashCode();
+        }
+        public Boolean equals(Object other) {
+            System.debug('in equals');
+            System.debug(this);
+            UpdateCall o = (UpdateCall) other;
+            System.debug(o);
+            return (
+                campaignId == o.campaignId
+                && rootSegmentId == o.rootSegmentId
+                && acquireLock == o.acquireLock
+            );
+        }
+    }
+
+    private class ServiceStubUpdateList extends CampaignList_TEST.ServiceStub {
+        public List<UpdateCall> calls = new List<UpdateCall>();
+        public override void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId, Boolean acquireLock) {
+            calls.add(new UpdateCall(campaignId, rootSegmentId, acquireLock));
+        }
     }
 
     @isTest

--- a/src/classes/CampaignListSegment.cls
+++ b/src/classes/CampaignListSegment.cls
@@ -456,8 +456,11 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * @description Get an appropriate BatchableSequence.Batch class that
          * can be executed to retrieve CampaignListMembers from this source and
          * persist those members to the database
+         *
+         * @param campaignId The id of the campaign to be refreshed
+         * @return BatchableSequence.Batch
          */
-        public abstract BatchableSequence.Batch getBatchProcessor();
+        public abstract BatchableSequence.Batch getBatchProcessor(Id campaignId);
     }
 
     /**
@@ -487,10 +490,14 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * persist those members to the database.  In this case, it will return
          * a BatchableSequence.Batch class appropriate for retrieving
          * CampaignListMembers from an existing Campaign.
+         *
+         * @param campaignId The id of the campaign to be refreshed
+         * @return CampaignListFromCampaignBatch
          */
-        public override BatchableSequence.Batch getBatchProcessor() {
+        public override BatchableSequence.Batch getBatchProcessor(Id campaignId) {
             CampaignListFromCampaignBatch batch = new CampaignListFromCampaignBatch(
                 getCampaignListId(),
+                campaignId,
                 sourceId,
                 'Campaign: ' + getSourceName()
             );
@@ -546,10 +553,14 @@ public abstract class CampaignListSegment implements CampaignList.Segment {
          * persist those members to the database.  In this case, it will return
          * a BatchableSequence.Batch class appropriate for retrieving
          * CampaignListMembers from a Report.
+         *
+         * @param campaignId the id of the Campaign to be refreshed
+         * @return CampaignListFromReportBatch
          */
-        public override BatchableSequence.Batch getBatchProcessor() {
+        public override BatchableSequence.Batch getBatchProcessor(Id campaignId) {
             CampaignListFromReportBatch batch = new CampaignListFromReportBatch(
                 getCampaignListId(),
+                campaignId,
                 sourceId,
                 columnName,
                 'Report: ' + getSourceName()

--- a/src/classes/CampaignListSegment_TEST.cls
+++ b/src/classes/CampaignListSegment_TEST.cls
@@ -66,6 +66,7 @@ private class CampaignListSegment_TEST {
     }
 
     private static testMethod void testCampaignSourceSegment() {
+        Id targetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
         Id segmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
         Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
         Id parentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
@@ -88,13 +89,15 @@ private class CampaignListSegment_TEST {
         System.assertEquals(false, segment.isExclusion());
         System.assertEquals('Test Campaign', segment.getSourceName());
 
-        CampaignListFromCampaignBatch batch = (CampaignListFromCampaignBatch) segment.getBatchProcessor();
+        CampaignListFromCampaignBatch batch = (CampaignListFromCampaignBatch) segment.getBatchProcessor(targetCampaignId);
         System.assertEquals(rootSegmentId, batch.rootSegmentId);
-        System.assertEquals(sourceId, batch.campaignId);
-        System.assertEquals('Campaign: Test Campaign', batch.campaignName);
+        System.assertEquals(targetCampaignId, batch.targetCampaignId);
+        System.assertEquals(sourceId, batch.sourceCampaignId);
+        System.assertEquals('Campaign: Test Campaign', batch.sourceCampaignName);
     }
 
     private static testMethod void testReportSourceSegment() {
+        Id targetCampaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
         Id segmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
         Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
         Id parentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
@@ -119,8 +122,10 @@ private class CampaignListSegment_TEST {
         System.assertEquals('test_column_name', segment.getColumnName());
         System.assertEquals('Test Report', segment.getSourceName());
 
-        CampaignListFromReportBatch batch = (CampaignListFromReportBatch) segment.getBatchProcessor();
+        CampaignListFromReportBatch batch = (CampaignListFromReportBatch) segment.getBatchProcessor(targetCampaignId);
+
         System.assertEquals(rootSegmentId, batch.rootSegmentId);
+        System.assertEquals(targetCampaignId, batch.targetCampaignId);
         System.assertEquals(sourceId, batch.reportId);
         System.assertEquals('Report: Test Report', batch.reportName);
         System.assertEquals('test_column_name', batch.idColumnName);

--- a/src/classes/CampaignListService.cls
+++ b/src/classes/CampaignListService.cls
@@ -64,7 +64,7 @@ public class CampaignListService implements CampaignList.Service {
         CampaignList.Segment segmentTree = CampaignList.getSegmentMapper().getSegmentTreeByRootId(rootSegmentId);
 
         batchSequence.add(new DeleteCampaignMembersBatch(campaignId), 5000);
-        batchSequence.add(new DeleteCampaignListMembersBatch(rootSegmentId), 5000);
+        batchSequence.add(new DeleteCampaignListMembersBatch(rootSegmentId, campaignId), 5000);
 
         Iterator<CampaignList.Segment> segmentTreeIterator = segmentTree.iterator();
 
@@ -72,7 +72,7 @@ public class CampaignListService implements CampaignList.Service {
             CampaignList.Segment next = segmentTreeIterator.next();
             if (next instanceof CampaignListSegment.SourceSegment) {
                 CampaignListSegment.SourceSegment sourceSegment = (CampaignListSegment.SourceSegment) next;
-                batchSequence.add(sourceSegment.getBatchProcessor());
+                batchSequence.add(sourceSegment.getBatchProcessor(campaignId));
             }
         }
 
@@ -128,6 +128,41 @@ public class CampaignListService implements CampaignList.Service {
         update c;
     }
 
+    /**
+     * @description In the event of an error during a Campaign refresh, we need to unlock the Campaign, mark it as failed, and log the error on the Campaign.
+     *
+     * @param campaignId The id of the Campaign to unlock and mark as failed
+     * @param errorMessage The error message to log to the Campaign record (max 255 chars)
+     */
+    public void unlockCampaignAndMarkFailed(Id campaignId, String errorMessage) {
+        Campaign c = [
+            SELECT
+                Campaign_List_Mutex__c,
+                Campaign_List_Update_Status__c,
+                Campaign_List_Error_Message__c
+            FROM Campaign
+            WHERE Id = :campaignId
+            FOR UPDATE
+        ];
+
+        c.Campaign_List_Mutex__c = null;
+        c.Campaign_List_Update_Status__c = 'Failed';
+        c.Campaign_List_Error_Message__c = errorMessage;
+
+        update c;
+    }
+
+    /**
+     * @description Get the number of slots available in the FlexQueue, if we
+     * wanted to make sure at least maxFreeSlots would be left available.  This
+     * will query the number of 'Holding' jobs in the FlexQueue, calculate how
+     * many slots are available in the FlexQueue without exceeding the
+     * 'Holding' limit, while reserving space for maxFreeSlots to remain
+     * available.
+     *
+     * @param maxFreeSlots How many slots we want to reserve as being available
+     * @return Integer The number of jobs that can be added to the FlexQueue while leaving at least maxFreeSlots remaining
+     */
     public Integer getFlexQueueCapacity(Integer maxFreeSlots) {
         Integer holdingJobCount = queryHoldingJobCount();
         Integer freeSlots = Math.max(100 - holdingJobCount, 0);
@@ -135,6 +170,12 @@ public class CampaignListService implements CampaignList.Service {
         return capacity;
     }
 
+    /**
+     * @description Query the number of jobs in the FlexQueue that are in
+     * 'Holding' status.
+     *
+     * @return Integer
+     */
     private Integer queryHoldingJobCount() {
         return [
             SELECT COUNT()
@@ -143,8 +184,33 @@ public class CampaignListService implements CampaignList.Service {
         ];
     }
 
+    /**
+     * @description Wrapper around System.enqueueJob().
+     *
+     * @param job The Queueable to pass to System.enqueueJob()
+     * @return Id The Id of the AsyncApexJob that was enqueued.
+     */
     public Id enqueueJob(Queueable job) {
         return System.enqueueJob(job);
+    }
+
+    /**
+     * @description Wrapper around Database.BatchableContext.getJobId()
+     *
+     * @param bc The BatchableContext to get the id of
+     * @return Id
+     */
+    public Id getJobId(Database.BatchableContext bc) {
+        return bc.getJobId();
+    }
+
+    /**
+     * @description Wrapper around System.abortJob()
+     *
+     * @param jobId The id of the AsyncApexJob to abort
+     */
+    public void abortJob(Id jobId) {
+        System.abortJob(jobId);
     }
 
     public virtual class CustomException extends Exception {}

--- a/src/classes/CampaignListService_TEST.cls
+++ b/src/classes/CampaignListService_TEST.cls
@@ -70,7 +70,7 @@ private class CampaignListService_TEST {
         mutexStub.acquireLock = true;
 
         CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
-        mutexFactory.m = mutexStub;
+        mutexFactory.createReturn = mutexStub;
         CampaignList.setMutexFactory(mutexFactory);
 
         CampaignListService service = new CampaignListService();
@@ -78,11 +78,11 @@ private class CampaignListService_TEST {
         // assert that the destination campaign was updated to indicate a
         // running update
 
-        System.assertEquals(destinationCampaignId, serviceStub.updatedCampaignId);
-        System.assertEquals(destinationCampaignId, mutexFactory.recordId);
-        System.assertEquals(Campaign.Campaign_List_Mutex__c, mutexFactory.mutexField);
+        System.assertEquals(destinationCampaignId, serviceStub.updateCampaignStatusCampaignId);
+        System.assertEquals(destinationCampaignId, mutexFactory.createRecordId);
+        System.assertEquals(Campaign.Campaign_List_Mutex__c, mutexFactory.createMutexField);
         System.assertEquals(1, mutexStub.acquireLockCalls);
-        System.assertEquals(CampaignList.UpdateStatus.Processing, serviceStub.updatedStatus);
+        System.assertEquals(CampaignList.UpdateStatus.Processing, serviceStub.updateCampaignStatusStatus);
 
         // assert that the batches in this sequence exist in the expected
         // order, with a report source batch and a campaign source batch (in
@@ -121,7 +121,8 @@ private class CampaignListService_TEST {
         System.assertEquals(sourceReportId, reportBatch.reportId);
         System.assertEquals('test_column_name', reportBatch.idColumnName);
         System.assertEquals(rootSegment.Id, campaignBatch.rootSegmentId);
-        System.assertEquals(sourceCampaignId, campaignBatch.campaignId);
+        System.assertEquals(destinationCampaignId, campaignBatch.targetCampaignId);
+        System.assertEquals(sourceCampaignId, campaignBatch.sourceCampaignId);
         System.assertEquals(rootSegment.Id, campaignListToCampaignBatch.rootSegment.getId());
         System.assertEquals(destinationCampaignId, campaignListToCampaignBatch.campaignId);
         System.assertEquals(rootSegment.Id, deleteCampaignListMembersBatch2.rootSegmentId);

--- a/src/classes/CampaignListToCampaignBatch.cls
+++ b/src/classes/CampaignListToCampaignBatch.cls
@@ -79,16 +79,30 @@ public class CampaignListToCampaignBatch extends BatchableSequence.Batch impleme
      * @return void
      */
     public void execute(Database.BatchableContext bc, List<Member__c> scope) {
-        List<CampaignList.Member> eligibleMembers = new List<CampaignList.Member>();
+        try {
+            List<CampaignList.Member> eligibleMembers = new List<CampaignList.Member>();
 
-        for (Member__c m : scope) {
-            CampaignList.Member member = new CampaignListMember(m);
-            if (member.meetsCriteria(rootSegment)) {
-                eligibleMembers.add(member);
+            for (Member__c m : scope) {
+                CampaignList.Member member = new CampaignListMember(m);
+                if (member.meetsCriteria(rootSegment)) {
+                    eligibleMembers.add(member);
+                }
             }
-        }
 
-        CampaignList.getMemberMapper().addMembersToCampaign(eligibleMembers, campaignId);
+            CampaignList.getMemberMapper().addMembersToCampaign(eligibleMembers, campaignId);
+        } catch (Exception e) {
+            CampaignList.Service service = CampaignList.getService();
+            service.unlockCampaignAndMarkFailed(
+                campaignId,
+                String.format(
+                    Label.CampaignToolsListToCampaignExecuteException,
+                    new List<String>{
+                        rootSegment.getId()
+                    }
+                )
+            );
+            service.abortJob(service.getJobId(bc));
+        }
     }
 
     /**

--- a/src/classes/CampaignListToCampaignBatch_TEST.cls
+++ b/src/classes/CampaignListToCampaignBatch_TEST.cls
@@ -47,7 +47,7 @@ private class CampaignListToCampaignBatch_TEST {
         insert member2;
 
         CampaignList_TEST.SegmentStub rootSegmentStub = new CampaignList_TEST.SegmentStub();
-        rootSegmentStub.segmentId = rootSegment.Id;
+        rootSegmentStub.getIdReturn = rootSegment.Id;
 
         CampaignListToCampaignBatch batch = new CampaignListToCampaignBatch(null, rootSegmentStub);
 
@@ -73,8 +73,11 @@ private class CampaignListToCampaignBatch_TEST {
 
         Id campaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        CampaignList_TEST.SegmentStub rootSegment = new CampaignList_TEST.SegmentStub();
-        rootSegment.acceptIds.add(member1.Id);
+        SegmentMeetsCriteriaStub rootSegment = new SegmentMeetsCriteriaStub();
+        rootSegment.meetsCriteriaReturnMap = new Map<Id, Boolean>{
+            member1.Id => true,
+            member2.Id => false
+        };
 
         CampaignList_TEST.MemberMapperStub mapperStub = new CampaignList_TEST.MemberMapperStub();
         CampaignList.setMemberMapper(mapperStub);
@@ -86,9 +89,27 @@ private class CampaignListToCampaignBatch_TEST {
             new List<Member__c>{member1, member2}
         );
 
-        System.assertEquals(campaignId, mapperStub.campaignId);
-        System.assertEquals(1, mapperStub.members.size());
-        System.assertEquals(member1.Id, mapperStub.members.get(0).getId());
+        System.assertEquals(
+            campaignId,
+            mapperStub.addMembersToCampaignCampaignId
+        );
+
+        System.assertEquals(
+            1,
+            mapperStub.addMembersToCampaignMembers.size()
+        );
+
+        System.assertEquals(
+            member1.Id,
+            mapperStub.addMembersToCampaignMembers.get(0).getId()
+        );
+    }
+
+    private class SegmentMeetsCriteriaStub extends CampaignList_TEST.SegmentStub {
+        public Map<Id, Boolean> meetsCriteriaReturnMap;
+        public override Boolean meetsCriteria(CampaignList.Member m) {
+            return meetsCriteriaReturnMap.get(m.getId());
+        }
     }
 
     public static testMethod void testExecuteBatch() {
@@ -96,7 +117,7 @@ private class CampaignListToCampaignBatch_TEST {
         mutexStub.releaseLock = true;
 
         CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
-        mutexFactory.m = mutexStub;
+        mutexFactory.createReturn = mutexStub;
         CampaignList.setMutexFactory(mutexFactory);
 
         CampaignList_TEST.SegmentStub rootSegment = new CampaignList_TEST.SegmentStub();
@@ -112,5 +133,45 @@ private class CampaignListToCampaignBatch_TEST {
         Test.stopTest();
 
         System.assertEquals(AsyncApexJob.sObjectType, jobId.getSobjectType());
+    }
+
+    public static testMethod void testExecuteHandlesException() {
+        Id campaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id jobId = CampaignList_TEST.getNextId(AsyncApexJob.sObjectType);
+
+        CampaignList_TEST.SegmentStub rootSegment = new CampaignList_TEST.SegmentStub();
+        rootSegment.getIdReturn = rootSegmentId;
+
+        CampaignList_TEST.MemberMapperStub memberMapper = new CampaignList_TEST.MemberMapperStub();
+        memberMapper.addMembersToCampaignException = new CampaignList_TEST.MockException();
+        CampaignList.setMemberMapper(memberMapper);
+
+        CampaignList_TEST.ServiceStub service = new CampaignList_TEST.ServiceStub();
+        service.getJobIdReturn = jobId;
+        CampaignList.setService(service);
+
+        CampaignListToCampaignBatch batch = new CampaignListToCampaignBatch(
+            campaignId,
+            rootSegment
+        );
+
+        batch.execute(null, new List<Member__c>());
+
+        System.assertEquals(
+            campaignId,
+            service.unlockCampaignAndMarkFailedCampaignId
+        );
+
+        System.assert(
+            service.unlockCampaignAndMarkFailedErrorMessage.contains(
+                rootSegmentId
+            )
+        );
+
+        System.assertEquals(
+            jobId,
+            service.abortJobJobId
+        );
     }
 }

--- a/src/classes/CampaignList_TEST.cls
+++ b/src/classes/CampaignList_TEST.cls
@@ -40,155 +40,192 @@ public class CampaignList_TEST {
         return id_x;
     }
 
-    public class SegmentStub implements CampaignList.Segment {
-        public Id segmentId;
-        public Id parentId;
-        public Id rootSegmentId;
-        public Set<Id> acceptIds = new Set<Id>();
-        public Boolean meetsCriteria(CampaignList.Member m) {
-            return acceptIds.contains(m.getId());
+    public virtual class SegmentStub implements CampaignList.Segment {
+        public CampaignList.Member meetsCriteraM;
+        public Boolean meetsCriteriaReturn;
+        public Id getIdReturn;
+        public Id setIdSegmentId;
+        public Id getParentIdReturn;
+        public Id setParentIdParentId;
+        public Id getRootSegmentIdReturn;
+        public Id setRootSegmentIdRootSegmentId;
+        public List<CampaignList.Segment> getChildrenReturn;
+        public Iterator<CampaignList.Segment> iteratorReturn;
+        public Segment__c getSObjectReturn;
+        public CampaignList.Segment addChildChild;
+        public virtual Boolean meetsCriteria(CampaignList.Member m) {
+            meetsCriteraM = m;
+            return this.meetsCriteriaReturn;
         }
-        public Id getId() {
-            return segmentId;
+        public virtual Id getId() {
+            return this.getIdReturn;
         }
-        public void setId(Id segmentId) {
-            this.segmentId = segmentId;
+        public virtual void setId(Id segmentId) {
+            this.setIdSegmentId = segmentId;
         }
-        public Id getParentId() {
-            return null;
+        public virtual Id getParentId() {
+            return this.getParentIdReturn;
         }
-        public void setParentId(Id parentId) {
-            this.parentId = parentId;
+        public virtual void setParentId(Id parentId) {
+            this.setParentIdParentId = parentId;
         }
-        public Id getRootSegmentId() {
-            return null;
+        public virtual Id getRootSegmentId() {
+            return this.getRootSegmentIdReturn;
         }
-        public void setRootSegmentId(Id rootSegmentId) {
-            this.rootSegmentId = rootSegmentId;
+        public virtual void setRootSegmentId(Id rootSegmentId) {
+            this.setRootSegmentIdRootSegmentId = rootSegmentId;
         }
-        public List<CampaignList.Segment> getChildren() {
-            return null;
+        public virtual List<CampaignList.Segment> getChildren() {
+            return this.getChildrenReturn;
         }
-        public Iterator<CampaignList.Segment> iterator() {
-            return null;
+        public virtual Iterator<CampaignList.Segment> iterator() {
+            return this.iteratorReturn;
         }
-        public Segment__c getSObject() {
-            return null;
+        public virtual Segment__c getSObject() {
+            return this.getSObjectReturn;
         }
-        public void addChild(CampaignList.Segment child) {}
-    }
-
-    public class MemberMapperStub implements CampaignList.MemberMapper {
-        public List<CampaignList.Member> members;
-        public Id campaignId;
-        public List<Id> relatedIds;
-        public Id rootSegmentId;
-        public Id sourceId;
-        public String sourceName;
-        public void addMembersToCampaign(List<CampaignList.Member> members, Id campaignId) {
-            this.members = members;
-            this.campaignId = campaignId;
-        }
-        public void updateByRelatedIdsAndSource(List<Id> relatedIds, Id rootSegmentId, Id sourceId, String sourceName) {
-            this.relatedIds = relatedIds;
-            this.rootSegmentId = rootSegmentId;
-            this.sourceId = sourceId;
-            this.sourceName = sourceName;
+        public virtual void addChild(CampaignList.Segment child) {
+            this.addChildChild = child;
         }
     }
 
-    public class SegmentMapperStub implements CampaignList.SegmentMapper {
-        public Id sourceId;
-        public Id rootSegmentId;
-        public String sourceName;
-        public String serialized;
-        public CampaignList.Segment rootSegment;
-        public String getSourceNameById(Id sourceId) {
-            this.sourceId = sourceId;
-            return sourceName;
-        }
-        public CampaignList.Segment getSegmentTreeByRootId(Id rootSegmentId) {
-            return null;
-        }
-        public Id upsertSegmentTreeByRootSegment(CampaignList.Segment rootSegment) {
-            this.rootSegment = rootSegment;
-            return rootSegmentId;
-        }
-        public CampaignList.Segment deserializeSegmentFromJSON(String serialized) {
-            this.serialized = serialized;
-            return null;
-        }
-    }
-
-    public class ServiceStub implements CampaignList.Service {
-        public Id updatedCampaignId;
-        public Id updatedRootSegmentId;
-        public Boolean updateCampaignFromCampaignListAcquireLock;
-        public List<Id> updateCampaignIdList = new List<Id>();
-        public List<Id> updateRootSegmentIdList = new List<Id>();
-        public List<Boolean> updateCampaignFromCampaignListAcquireLockList = new List<Boolean>();
-        public CampaignList.UpdateStatus updatedStatus;
-        public Boolean throwAlreadyRunningException = false;
-        public Integer flexQueueCapacity;
-        public Integer maxFreeSlots;
-        public Queueable enqueueJobJob;
-        public Id enqueueJobId;
-        public void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId) {
-            updatedCampaignId = campaignId;
-            updatedRootSegmentId = rootSegmentId;
-            if (throwAlreadyRunningException) {
-                throw new CampaignListService.CampaignListUpdateAlreadyRunningException();
+    public virtual class MemberMapperStub implements CampaignList.MemberMapper {
+        public List<CampaignList.Member> addMembersToCampaignMembers;
+        public Id addMembersToCampaignCampaignId;
+        public Exception addMembersToCampaignException;
+        public List<Id> updateByRelatedIdsAndSourceRelatedIds;
+        public Id updateByRelatedIdsAndSourceRootSegmentId;
+        public Id updateByRelatedIdsAndSourceSourceId;
+        public String updateByRelatedIdsAndSourceSourceName;
+        public Exception updateByRelatedIdsAndSourceException;
+        public virtual void addMembersToCampaign(List<CampaignList.Member> members, Id campaignId) {
+            this.addMembersToCampaignMembers = members;
+            this.addMembersToCampaignCampaignId = campaignId;
+            if (null != this.addMembersToCampaignException) {
+                throw this.addMembersToCampaignException;
             }
         }
-        public void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId, Boolean acquireLock) {
-            updatedCampaignId = campaignId;
-            updatedRootSegmentId = rootSegmentId;
-            updateCampaignFromCampaignListAcquireLock = acquireLock;
-            updateCampaignIdList.add(campaignId);
-            updateRootSegmentIdList.add(rootSegmentId);
-            updateCampaignFromCampaignListAcquireLockList.add(acquireLock);
+        public virtual void updateByRelatedIdsAndSource(List<Id> relatedIds, Id rootSegmentId, Id sourceId, String sourceName) {
+            this.updateByRelatedIdsAndSourceRelatedIds = relatedIds;
+            this.updateByRelatedIdsAndSourceRootSegmentId = rootSegmentId;
+            this.updateByRelatedIdsAndSourceSourceId = sourceId;
+            this.updateByRelatedIdsAndSourceSourceName = sourceName;
+            if (null != this.updateByRelatedIdsAndSourceException) {
+                throw this.updateByRelatedIdsAndSourceException;
+            }
         }
-        public void updateCampaignStatus(Id campaignId, CampaignList.UpdateStatus status) {
-            updatedCampaignId = campaignId;
-            updatedStatus = status;
+    }
+
+    public virtual class SegmentMapperStub implements CampaignList.SegmentMapper {
+        public Id getSourceNameByIdSourceId;
+        public String getSourceNameByIdReturn;
+        public Id getSegmentTreeByRootIdRootSegmentId;
+        public CampaignList.Segment getSegmentTreeByRootIdReturn;
+        public CampaignList.Segment upsertSegmentTreeByRootSegmentRootSegment;
+        public Id upsertSegmentTreeByRootSegmentReturn;
+        public String deserializeSegmentFromJSONSerialized;
+        public CampaignList.Segment deserializeSegmentFromJSONReturn;
+        public virtual String getSourceNameById(Id sourceId) {
+            this.getSourceNameByIdSourceId = sourceId;
+            return this.getSourceNameByIdReturn;
         }
-        public Integer getFlexQueueCapacity(Integer maxFreeSlots) {
-            this.maxFreeSlots = maxFreeSlots;
-            return flexQueueCapacity;
+        public virtual CampaignList.Segment getSegmentTreeByRootId(Id rootSegmentId) {
+            this.getSegmentTreeByRootIdRootSegmentId = rootSegmentId;
+            return this.getSegmentTreeByRootIdReturn;
         }
-        public Id enqueueJob(Queueable job) {
+        public virtual Id upsertSegmentTreeByRootSegment(CampaignList.Segment rootSegment) {
+            this.upsertSegmentTreeByRootSegmentRootSegment = rootSegment;
+            return this.upsertSegmentTreeByRootSegmentReturn;
+        }
+        public virtual CampaignList.Segment deserializeSegmentFromJSON(String serialized) {
+            this.deserializeSegmentFromJSONSerialized = serialized;
+            return this.deserializeSegmentFromJSONReturn;
+        }
+    }
+
+    public virtual class ServiceStub implements CampaignList.Service {
+        public Id updateCampaignFromCampaignListCampaignId;
+        public Id updateCampaignFromCampaignListRootSegmentId;
+        public Exception updateCampaignFromCampaignListException;
+        public Boolean updateCampaignFromCampaignListAcquireLock;
+        public Id updateCampaignStatusCampaignId;
+        public CampaignList.UpdateStatus updateCampaignStatusStatus;
+        public Id unlockCampaignAndMarkFailedCampaignId;
+        public String unlockCampaignAndMarkFailedErrorMessage;
+        public Integer getFlexQueueCapacityMaxFreeSlots;
+        public Integer getFlexQueueCapacityReturn;
+        public Queueable enqueueJobJob;
+        public Id enqueueJobReturn;
+        public Database.BatchableContext getJobIdBc;
+        public Id getJobIdReturn;
+        public Id abortJobJobId;
+        public virtual void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId) {
+            this.updateCampaignFromCampaignListCampaignId = campaignId;
+            this.updateCampaignFromCampaignListRootSegmentId = rootSegmentId;
+            if (null != this.updateCampaignFromCampaignListException) {
+                throw this.updateCampaignFromCampaignListException;
+            }
+        }
+        public virtual void updateCampaignFromCampaignList(Id campaignId, Id rootSegmentId, Boolean acquireLock) {
+            this.updateCampaignFromCampaignListCampaignId = campaignId;
+            this.updateCampaignFromCampaignListRootSegmentId = rootSegmentId;
+            this.updateCampaignFromCampaignListAcquireLock = acquireLock;
+            if (null != this.updateCampaignFromCampaignListException) {
+                throw this.updateCampaignFromCampaignListException;
+            }
+        }
+        public virtual void updateCampaignStatus(Id campaignId, CampaignList.UpdateStatus status) {
+            this.updateCampaignStatusCampaignId = campaignId;
+            this.updateCampaignStatusStatus = status;
+        }
+        public virtual void unlockCampaignAndMarkFailed(Id campaignId, String errorMessage) {
+            this.unlockCampaignAndMarkFailedCampaignId = campaignId;
+            this.unlockCampaignAndMarkFailedErrorMessage = errorMessage;
+        }
+        public virtual Integer getFlexQueueCapacity(Integer maxFreeSlots) {
+            this.getFlexQueueCapacityMaxFreeSlots = maxFreeSlots;
+            return this.getFlexQueueCapacityReturn;
+        }
+        public virtual Id enqueueJob(Queueable job) {
             this.enqueueJobJob = job;
-            return enqueueJobId;
+            return this.enqueueJobReturn;
+        }
+        public virtual Id getJobId(Database.BatchableContext bc) {
+            this.getJobIdBc = bc;
+            return this.getJobIdReturn;
+        }
+        public virtual void abortJob(Id jobId) {
+            this.abortJobJobId = jobId;
         }
     }
 
-    public class MutexStubFactory implements Mutex.Factory {
-        public Id recordId;
-        public Schema.SObjectField mutexField;
-        public Mutex.MutexInterface m;
-        public Mutex.MutexInterface create(Id recordId, Schema.SObjectField mutexField) {
-            this.recordId = recordId;
-            this.mutexField = mutexField;
-            return m;
+    public virtual class MutexStubFactory implements Mutex.Factory {
+        public Id createRecordId;
+        public Schema.SObjectField createMutexField;
+        public Mutex.MutexInterface createReturn;
+        public virtual Mutex.MutexInterface create(Id recordId, Schema.SObjectField mutexField) {
+            this.createRecordId = recordId;
+            this.createMutexField = mutexField;
+            return this.createReturn;
         }
     }
 
-    public class MutexStub implements Mutex.MutexInterface {
+    public virtual class MutexStub implements Mutex.MutexInterface {
         public Integer acquireLockCalls = 0;
         public Integer releaseLockCalls = 0;
         public Integer getLockTimeCalls = 0;
         public Boolean acquireLock;
         public Boolean releaseLock;
         public DateTime lockTime;
-        public Boolean acquireLock() {
+        public virtual Boolean acquireLock() {
             acquireLockCalls++;
             return acquireLock;
         }
-        public Boolean releaseLock() {
+        public virtual Boolean releaseLock() {
             releaseLockCalls++;
             return releaseLock;
         }
-        public DateTime getLockTime() {
+        public virtual DateTime getLockTime() {
             getLockTimeCalls++;
             return lockTime;
         }
@@ -243,4 +280,6 @@ public class CampaignList_TEST {
             insert campaignMembers;
         }
     }
+
+    public class MockException extends Exception {}
 }

--- a/src/classes/DeleteCampaignListMembersBatch.cls
+++ b/src/classes/DeleteCampaignListMembersBatch.cls
@@ -54,8 +54,8 @@ public class DeleteCampaignListMembersBatch extends BatchableSequence.Batch impl
      *
      * @param rootSegmentId The "campaign list" id
      */
-    public DeleteCampaignListMembersBatch(Id rootSegmentId) {
-        this.rootSegmentId = rootSegmentId;
+    public DeleteCampaignListMembersBatch(Id rootSegmentId, Id campaignId) {
+        this(rootSegmentId, campaignId, false);
     }
 
     /**
@@ -66,7 +66,7 @@ public class DeleteCampaignListMembersBatch extends BatchableSequence.Batch impl
      * @param isFinalCleanup Is this the final cleanup pass?
      */
     public DeleteCampaignListMembersBatch(Id rootSegmentId, Id campaignId, Boolean isFinalCleanup) {
-        this(rootSegmentId);
+        this.rootSegmentId = rootSegmentId;
         this.campaignId = campaignId;
         this.isFinalCleanup = isFinalCleanup;
     }
@@ -91,8 +91,22 @@ public class DeleteCampaignListMembersBatch extends BatchableSequence.Batch impl
      * @return void
      */
     public void execute(Database.BatchableContext bc, List<Member__c> scope) {
-        delete scope;
-        Database.emptyRecycleBin(scope);
+        try {
+            delete scope;
+            Database.emptyRecycleBin(scope);
+        } catch (Exception e) {
+            CampaignList.Service service = CampaignList.getService();
+            service.unlockCampaignAndMarkFailed(
+                campaignId,
+                String.format(
+                    Label.CampaignToolsDeleteCampaignListMembersExecuteException,
+                    new List<String>{
+                        rootSegmentId
+                    }
+                )
+            );
+            service.abortJob(service.getJobId(bc));
+        }
     }
 
     /**

--- a/src/classes/DeleteCampaignListMembersBatch_TEST.cls
+++ b/src/classes/DeleteCampaignListMembersBatch_TEST.cls
@@ -30,6 +30,8 @@
 @isTest
 private class DeleteCampaignListMembersBatch_TEST {
     private static testMethod void testDeleteCampaignListMembersBatch() {
+        Id campaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+
         Segment__c rootSegment = new Segment__c();
         insert rootSegment;
 
@@ -50,7 +52,10 @@ private class DeleteCampaignListMembersBatch_TEST {
 
         System.assertEquals(200, listMemberCount);
 
-        DeleteCampaignListMembersBatch batch = new DeleteCampaignListMembersBatch(rootSegment.Id);
+        DeleteCampaignListMembersBatch batch = new DeleteCampaignListMembersBatch(
+            rootSegment.Id,
+            campaignId
+        );
         batch.setScope(200);
 
         Test.startTest();
@@ -70,8 +75,12 @@ private class DeleteCampaignListMembersBatch_TEST {
 
     public static testMethod void testFinish() {
         Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id campaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
 
-        DeleteCampaignListMembersBatch batch = new DeleteCampaignListMembersBatch(rootSegmentId);
+        DeleteCampaignListMembersBatch batch = new DeleteCampaignListMembersBatch(
+            rootSegmentId,
+            campaignId
+        );
 
         CampaignList_TEST.ServiceStub listServiceStub = new CampaignList_TEST.ServiceStub();
 
@@ -81,13 +90,20 @@ private class DeleteCampaignListMembersBatch_TEST {
         mutexStub.releaseLock = true;
 
         CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
-        mutexFactory.m = mutexStub;
+        mutexFactory.createReturn = mutexStub;
         CampaignList.setMutexFactory(mutexFactory);
 
         batch.finish(null);
 
-        System.assertEquals(null, listServiceStub.updatedCampaignId);
-        System.assertEquals(null, listServiceStub.updatedStatus);
+        System.assertEquals(
+            null,
+            listServiceStub.updateCampaignStatusCampaignId
+        );
+
+        System.assertEquals(
+            null,
+            listServiceStub.updateCampaignStatusStatus
+        );
     }
 
     public static testMethod void testFinishFinalCleanup() {
@@ -104,12 +120,52 @@ private class DeleteCampaignListMembersBatch_TEST {
         mutexStub.releaseLock = true;
 
         CampaignList_TEST.MutexStubFactory mutexFactory = new CampaignList_TEST.MutexStubFactory();
-        mutexFactory.m = mutexStub;
+        mutexFactory.createReturn = mutexStub;
         CampaignList.setMutexFactory(mutexFactory);
 
         batch.finish(null);
 
-        System.assertEquals(campaignId, listServiceStub.updatedCampaignId);
-        System.assertEquals(CampaignList.UpdateStatus.Completed, listServiceStub.updatedStatus);
+        System.assertEquals(
+            campaignId,
+            listServiceStub.updateCampaignStatusCampaignId
+        );
+
+        System.assertEquals(
+            CampaignList.UpdateStatus.Completed,
+            listServiceStub.updateCampaignStatusStatus
+        );
+    }
+
+    private static testMethod void testExecuteHandlesException() {
+        Id rootSegmentId = CampaignList_TEST.getNextId(Segment__c.sObjectType);
+        Id campaignId = CampaignList_TEST.getNextId(Campaign.sObjectType);
+        Id jobId = CampaignList_TEST.getNextId(AsyncApexJob.sObjectType);
+
+        CampaignList_TEST.ServiceStub service = new CampaignList_TEST.ServiceStub();
+        service.getJobIdReturn = jobId;
+        CampaignList.setService(service);
+
+        DeleteCampaignListMembersBatch batch = new DeleteCampaignListMembersBatch(
+            rootSegmentId,
+            campaignId
+        );
+
+        batch.execute(null, null);
+
+        System.assertEquals(
+            campaignId,
+            service.unlockCampaignAndMarkFailedCampaignId
+        );
+
+        System.assert(
+            service.unlockCampaignAndMarkFailedErrorMessage.contains(
+                rootSegmentId
+            )
+        );
+
+        System.assertEquals(
+            jobId,
+            service.abortJobJobId
+        );
     }
 }

--- a/src/classes/ProcessSegmentBTN_TEST.cls
+++ b/src/classes/ProcessSegmentBTN_TEST.cls
@@ -57,8 +57,15 @@ private with sharing class ProcessSegmentBTN_TEST {
 
         System.assertEquals(null, pr);
 
-        System.assertEquals(campaignId, serviceStub.updatedCampaignId);
-        System.assertEquals(rootSegmentId, serviceStub.updatedRootSegmentId);
+        System.assertEquals(
+            campaignId,
+            serviceStub.updateCampaignFromCampaignListCampaignId
+        );
+
+        System.assertEquals(
+            rootSegmentId,
+            serviceStub.updateCampaignFromCampaignListRootSegmentId
+        );
     }
 
     @isTest
@@ -98,8 +105,15 @@ private with sharing class ProcessSegmentBTN_TEST {
 
         System.assertEquals(null, pr);
 
-        System.assertEquals(null, serviceStub.updatedCampaignId);
-        System.assertEquals(null, serviceStub.updatedRootSegmentId);
+        System.assertEquals(
+            null,
+            serviceStub.updateCampaignFromCampaignListCampaignId
+        );
+
+        System.assertEquals(
+            null,
+            serviceStub.updateCampaignFromCampaignListRootSegmentId
+        );
     }
 
     @isTest
@@ -114,7 +128,7 @@ private with sharing class ProcessSegmentBTN_TEST {
         );
 
         CampaignList_TEST.ServiceStub serviceStub = new CampaignList_TEST.ServiceStub();
-        serviceStub.throwAlreadyRunningException = true;
+        serviceStub.updateCampaignFromCampaignListException = new CampaignListService.CampaignListUpdateAlreadyRunningException();
 
         CampaignList.setService(serviceStub);
 
@@ -151,7 +165,14 @@ private with sharing class ProcessSegmentBTN_TEST {
 
         System.assertEquals(null, pr);
 
-        System.assertEquals(campaignId, serviceStub.updatedCampaignId);
-        System.assertEquals(rootSegmentId, serviceStub.updatedRootSegmentId);
+        System.assertEquals(
+            campaignId,
+            serviceStub.updateCampaignFromCampaignListCampaignId
+        );
+
+        System.assertEquals(
+            rootSegmentId,
+            serviceStub.updateCampaignFromCampaignListRootSegmentId
+        );
     }
 }

--- a/src/classes/ReportService.cls
+++ b/src/classes/ReportService.cls
@@ -172,6 +172,20 @@ public class ReportService implements CampaignList.ReportService {
         public ReportRowIdIterableIterator(Id reportId, String columnName) {
             this.reportId = reportId;
             this.columnName = columnName;
+
+            /*
+            We call getReportResults() in the constructor because if there are
+            going to be any problems running the report this first time, we
+            want the error to hit sooner rather than later.  This early failure
+            is necessary in order to be able to catch the exception within the
+            start() method of the Batchable that consumes this class. If the
+            error only became apparent after calling hasNext() or next() after
+            returning this Iterable from the start() method, then we would not
+            be able to catch that error since those calls happen in a context
+            we do not have control over.
+            */
+
+            ReportService.getReportResults(reportId, columnName, null);
         }
 
         /**

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -41,6 +41,38 @@
         <value>Could not update campaign {0}.</value>
     </labels>
     <labels>
+        <fullName>CampaignToolsDeleteCampaignListMembersExecuteException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CampaignToolsDeleteCampaignListMembersExecuteException</shortDescription>
+        <value>There was an error while trying to delete the temporary member records, as specified by campaign list with id {0}.</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsListFromCampaignExecuteException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CampaignToolsListFromCampaignExecuteException</shortDescription>
+        <value>There was an error while retrieving contacts or leads from the source campaign with id {0}, as specified by campaign list with id {1}</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsListFromReportExecuteException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CampaignToolsListFromReportExecuteException</shortDescription>
+        <value>There was an error while reading rows from report with id {0}, as specified by campaign list {1}.</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsListFromReportStartException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CampaignToolsListFromReportStartException</shortDescription>
+        <value>There was an error while trying to begin reading from report with id {0}, as specified by campaign list {1}.</value>
+    </labels>
+    <labels>
         <fullName>CampaignToolsListRefreshPageTitle</fullName>
         <categories>CampaignTools</categories>
         <language>en_US</language>
@@ -103,6 +135,14 @@
         <protected>true</protected>
         <shortDescription>CampaignToolsListRefreshStatusQueuedMessage</shortDescription>
         <value>The refresh process could take a while.  You can stay on this page to monitor the progress of the refresh process, or you can navigate away from this page and the refresh process will continue to run in the background.</value>
+    </labels>
+    <labels>
+        <fullName>CampaignToolsListToCampaignExecuteException</fullName>
+        <categories>CampaignTools,Exceptions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>CampaignToolsListToCampaignExecuteException</shortDescription>
+        <value>There was an error while populating this campaign with campaign members, as specified by campaign list with id {0}.</value>
     </labels>
     <labels>
         <fullName>CampaignToolsNoSavedCampaignList</fullName>

--- a/src/objects/Campaign.object
+++ b/src/objects/Campaign.object
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
+        <fullName>Campaign_List_Error_Message__c</fullName>
+        <description>If there was an error while attempting to update this Campaign using a Campaign List, then this field will show that error message.</description>
+        <externalId>false</externalId>
+        <label>Campaign List Refresh Error Message</label>
+        <length>255</length>
+        <required>false</required>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Campaign_List_Last_Updated__c</fullName>
         <description>This contains the date/time of when this Campaign was last successfully populated by a Campaign List</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -66,6 +66,7 @@
         <name>AuraDefinitionBundle</name>
     </types>
     <types>
+        <members>Campaign.Campaign_List_Error_Message__c</members>
         <members>Campaign.Campaign_List_Last_Updated__c</members>
         <members>Campaign.Campaign_List_Mutex__c</members>
         <members>Campaign.Campaign_List_Refresh_Automatically__c</members>
@@ -93,6 +94,10 @@
         <members>CampaignToolsAlreadyRunningWarningSummary</members>
         <members>CampaignToolsCantFinishUpdateException</members>
         <members>CampaignToolsCantUpdateException</members>
+        <members>CampaignToolsDeleteCampaignListMembersExecuteException</members>
+        <members>CampaignToolsListFromCampaignExecuteException</members>
+        <members>CampaignToolsListFromReportExecuteException</members>
+        <members>CampaignToolsListFromReportStartException</members>
         <members>CampaignToolsListRefreshPageTitle</members>
         <members>CampaignToolsListRefreshStatusAbortedHeading</members>
         <members>CampaignToolsListRefreshStatusCompletedHeading</members>
@@ -101,6 +106,7 @@
         <members>CampaignToolsListRefreshStatusProcessingMessage</members>
         <members>CampaignToolsListRefreshStatusQueuedHeading</members>
         <members>CampaignToolsListRefreshStatusQueuedMessage</members>
+        <members>CampaignToolsListToCampaignExecuteException</members>
         <members>CampaignToolsNoSavedCampaignList</members>
         <members>CampaignToolsReleaseLockException</members>
         <members>JobProgressCompletedLabel</members>


### PR DESCRIPTION
Add `CampaignList.Service.unlockCampaignAndMarkFailed()` method.  This is a convenience method intended to be called from the error handling code in the various batch classes.  It will unlock the campaign, mark the status as 'Failed', and also log any provided error message to the specified campaign.

Refactor stub test classes to make naming convention more uniform.  Remove some special case code from stub classes to stub sub classes where some tests needed special behavior (like logging a sequence of calls, as opposed to just the first call, etc.).  All test classes have been updated to use the new naming convention.

Add some system class wrappers to service class.  This gives the ability to stub calls to `BatchableContext.getJobId()` and `System.abortJob()` to verify classes are correctly calling those methods, but not need to create real jobs in order to get test coverage.

Since batch jobs now need to be able to unlock the campaign that is being refreshed, all batches now need to be aware of the target campaign of the refresh process.  All batch classes have been updated to include a reference to this campaign by id, and this has been added to the constructor signatures where necessary.

Each batch class has had a try/catch block added to wrap the contents of the `execute()` method, and in some cases also the `start()` method.  This includes: `CampaignListFromCampaignBatch`, `CampaignListFromReportBatch`, `CampaignListToCampaignBatch`, and `DeleteCampaignListMembersBatch`.  `DeleteCampaignMembersBatch` was not modified, since it is expected to be removed as part of future work.

New tests to verify exception handling in batch classes.

`CampaignListFromReportBatch.IdIterableFactory` interface was added to allow stubbing the creation of the iterable in the `start()` method.  This was necessary in order to be able to trigger a fake exception from a test in order to verify the exception handling of the `start()` method.

New labels added for error messages that are created as part of the exception handling in batch classes.

New field added to Campaign for storing error message from batch.