### PR TITLE
Remove override of run_tests_debug

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -6,10 +6,3 @@ project:
         api_version: 37.0
     git:
         prefix_release: rel/
-
-flows:
-    ci_feature:
-        tasks:
-            # CumulusCI's debug log parser errors if using test data loads, so don't parse debug logs on tests
-            8:
-                task: run_tests


### PR DESCRIPTION
The cumulusci.yml had a temporary workaround for a bug in CumulusCI where the run_tests_debug task would fail when parsing debug logs of test classes with a @testSetup decorated method.  The CumulusCI bug is fixed and this removes the workaround so we can get limits usage data for tests on this repo.