### PR TITLE
Feature/jen validation

### DIFF
--- a/src/classes/CampaignTriggerHandler.cls
+++ b/src/classes/CampaignTriggerHandler.cls
@@ -1,0 +1,86 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @group CampaignTools
+ * @description Trigger Handler on Campaign
+ */
+public with sharing class CampaignTriggerHandler {
+    /** @description A static map of the original state of the new or updated campaign objects */
+    private static Map<Id, Campaign> mapNewOldCamp = new Map<Id, Campaign>();
+    /** @description A static list AsyncApexJobs that match the CampaignListRefresh criteria */
+    private static List<AsyncApexJob> listCampRefreshJobs;
+
+    /*******************************************************************************************************
+    * @description Trigger Handler on Campaign to validate the campaign objects before insert
+    * @param listNewCamp the list of Campaigns from trigger new
+    ********************************************************************************************************/
+	public static void handleBeforeInsert(List<Campaign> listNewCamp) {
+        validateCampaignRefresh(new List<Campaign>(), listNewCamp);
+    }
+    /*******************************************************************************************************
+    * @description Trigger Handler on Campaign to validate the campaign objects before insert
+    * @param listOldCamp the list of Campaigns from trigger old
+    * @param listNewCamp the list of Campaigns from trigger new
+    ********************************************************************************************************/
+    public static void handleBeforeUpdate(List<Campaign> listOldCamp, List<Campaign> listNewCamp) {
+        validateCampaignRefresh(listOldCamp, listNewCamp);
+    }
+    /*******************************************************************************************************
+    * @description Adds an error to any campaign set to refresh when a schedule is not present
+    * @param listOldCamp the list of Campaigns from trigger old
+    * @param listNewCamp the list of Campaigns from trigger new
+    ********************************************************************************************************/
+    public static void validateCampaignRefresh(List<Campaign> listOldCamp, List<Campaign> listNewCamp) {
+        if (listCampRefreshJobs == null){
+            // scheduled Apex jobs will always stays in the Queued status until the job has no NextFireTime,
+            // then it gets marked Completed, or if the job is aborted then it gets marked Aborted
+            listCampRefreshJobs = [SELECT Id FROM AsyncApexJob
+                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
+                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
+        }
+        if (!listCampRefreshJobs.isEmpty())
+            return; // no need to process the refresh job is scheduled
+
+        Map<Id, Campaign> mapOldCamp = new Map<Id, Campaign>(listOldCamp);
+        for (Campaign newCamp : listNewCamp) {
+            Campaign oldCamp;
+            if (mapNewOldCamp.containsKey(newCamp.Id)) {
+                oldCamp = mapNewOldCamp.get(newCamp.Id);
+            } else {
+                oldCamp = mapOldCamp.containsKey(newCamp.Id) ? mapOldCamp.get(newCamp.Id) : new Campaign();
+                mapNewOldCamp.put(newCamp.Id, newCamp);
+            }
+            if (newCamp.Campaign_List_Refresh_Automatically__c && !oldCamp.Campaign_List_Refresh_Automatically__c) {
+                newCamp.addError(Label.CampaignToolsRefreshScheduleValidation, false);
+            }
+        }
+    }
+}

--- a/src/classes/CampaignTriggerHandler.cls
+++ b/src/classes/CampaignTriggerHandler.cls
@@ -37,21 +37,25 @@ public with sharing class CampaignTriggerHandler {
     private static Map<Id, Campaign> mapNewOldCamp = new Map<Id, Campaign>();
     /** @description A static list AsyncApexJobs that match the CampaignListRefresh criteria */
     private static List<AsyncApexJob> listCampRefreshJobs;
+    /** @description Boolean flag to determine if validation should run defaults to true if test not running */
+    @TestVisible private static Boolean validate = !Test.isRunningTest();
 
     /*******************************************************************************************************
     * @description Trigger Handler on Campaign to validate the campaign objects before insert
     * @param listNewCamp the list of Campaigns from trigger new
     ********************************************************************************************************/
 	public static void handleBeforeInsert(List<Campaign> listNewCamp) {
-        validateCampaignRefresh(new List<Campaign>(), listNewCamp);
+        if (!isCampaignRefreshScheduled() && validate)
+            validateCampaignRefresh(new List<Campaign>(), listNewCamp);
     }
     /*******************************************************************************************************
-    * @description Trigger Handler on Campaign to validate the campaign objects before insert
+    * @description Trigger Handler on Campaign to validate the campaign objects before update
     * @param listOldCamp the list of Campaigns from trigger old
     * @param listNewCamp the list of Campaigns from trigger new
     ********************************************************************************************************/
     public static void handleBeforeUpdate(List<Campaign> listOldCamp, List<Campaign> listNewCamp) {
-        validateCampaignRefresh(listOldCamp, listNewCamp);
+        if (!isCampaignRefreshScheduled() && validate)
+            validateCampaignRefresh(listOldCamp, listNewCamp);
     }
     /*******************************************************************************************************
     * @description Adds an error to any campaign set to refresh when a schedule is not present
@@ -59,16 +63,6 @@ public with sharing class CampaignTriggerHandler {
     * @param listNewCamp the list of Campaigns from trigger new
     ********************************************************************************************************/
     public static void validateCampaignRefresh(List<Campaign> listOldCamp, List<Campaign> listNewCamp) {
-        if (listCampRefreshJobs == null){
-            // scheduled Apex jobs will always stays in the Queued status until the job has no NextFireTime,
-            // then it gets marked Completed, or if the job is aborted then it gets marked Aborted
-            listCampRefreshJobs = [SELECT Id FROM AsyncApexJob
-                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
-                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
-        }
-        if (!listCampRefreshJobs.isEmpty())
-            return; // no need to process the refresh job is scheduled
-
         Map<Id, Campaign> mapOldCamp = new Map<Id, Campaign>(listOldCamp);
         for (Campaign newCamp : listNewCamp) {
             Campaign oldCamp;
@@ -82,5 +76,19 @@ public with sharing class CampaignTriggerHandler {
                 newCamp.addError(Label.CampaignToolsRefreshScheduleValidation, false);
             }
         }
+    }
+    /*******************************************************************************************************
+    * @description Check to see if the refresh job is scheduled
+    * @return Boolean true when job is scheduled
+    ********************************************************************************************************/
+    public static Boolean isCampaignRefreshScheduled() {
+        if (listCampRefreshJobs == null){
+            // scheduled Apex jobs will always stays in the Queued status until the job has no NextFireTime,
+            // then it gets marked Completed, or if the job is aborted then it gets marked Aborted
+            listCampRefreshJobs = [SELECT Id FROM AsyncApexJob
+                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
+                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
+        }
+        return !listCampRefreshJobs.isEmpty();
     }
 }

--- a/src/classes/CampaignTriggerHandler.cls-meta.xml
+++ b/src/classes/CampaignTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CampaignTriggerHandler_TEST.cls
+++ b/src/classes/CampaignTriggerHandler_TEST.cls
@@ -1,0 +1,157 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @group CampaignTools
+ * @description Tests for CampaignTriggerHandler
+ */
+@isTest
+public with sharing class CampaignTriggerHandler_TEST {
+    @isTest
+	private static void testNewCampsWithoutScheduleNoRefresh() {
+        List<Campaign> listNewCamps = generateCampaigns(1, false);
+        Test.startTest();
+        insert listNewCamps;
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps];
+
+        System.assertEquals(listNewCamps.size(), queriedResults.size(), 'Records should have inserted without issue.');
+    }
+
+    @isTest
+    private static void testNewCampsWithoutScheduleWithRefresh() {
+        List<Campaign> listNewCamps = generateCampaigns(1, true);
+        Test.startTest();
+        try {
+            insert listNewCamps;
+            System.assert(false, 'Insert should fail and should leave try block.');
+        } catch(Exception ex) {
+            System.assert(true, 'Insert should fail and enter catch block.');
+        }
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps];
+
+        System.assert(queriedResults.isEmpty());
+    }
+
+    @isTest
+    private static void testUpdateCampsWithoutScheduleNoRefresh() {
+        List<Campaign> listNewCamps = generateCampaigns(1, false);
+        insert listNewCamps;
+        for (Campaign newCamps : listNewCamps) {
+            newCamps.Name += ' Updating';
+        }
+
+        Test.startTest();
+        update listNewCamps;
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps AND Name LIKE '% Updating'];
+
+        System.assertEquals(listNewCamps.size(), queriedResults.size(), 'Records should have updated without issue.');
+    }
+
+    @isTest
+    private static void testUpdateCampsWithoutScheduleWithRefresh() {
+        List<Campaign> listNewCamps = generateCampaigns(1, false);
+        insert listNewCamps;
+        for (Campaign newCamps : listNewCamps) {
+            newCamps.Name += ' Updating';
+            newCamps.Campaign_List_Refresh_Automatically__c = true;
+        }
+
+        Test.startTest();
+        try {
+            update listNewCamps;
+            System.assert(false, 'Update should fail and should leave try block.');
+        } catch (Exception ex) {
+            System.assert(true, 'Insert should fail and enter catch block.');
+        }
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps AND Name LIKE '% Updating'];
+
+        System.assert(queriedResults.isEmpty(), 'Records should have failed to update.');
+    }
+
+    @isTest
+    private static void testCampsWithScheduleMixBulk() {
+        List<Campaign> listNewCamps = generateCampaigns(100, false);
+        listNewCamps.addAll(generateCampaigns(100, true));
+        Test.startTest();
+        scheduleJob();
+        insert listNewCamps;
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps];
+        List<AsyncApexJob> listCampRefreshJobs = [SELECT Id FROM AsyncApexJob
+                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
+                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
+
+        System.assertEquals(listCampRefreshJobs.size(), 1, 'There should be a scheduled job found.');
+        System.assertEquals(listNewCamps.size(), queriedResults.size(), 'Records should have inserted without issue.');
+    }
+
+    @isTest
+    private static void testCampsWithoutScheduleMixBulk() {
+        List<Campaign> listNewCamps = generateCampaigns(200, false);
+        listNewCamps.addAll(generateCampaigns(200, true));
+        Test.startTest();
+        try {
+            insert listNewCamps;
+            System.assert(false, 'Update should fail and should leave try block.');
+        } catch(Exception ex) {
+            System.assert(true, 'Insert should fail and enter catch block.');
+        }
+        Test.stopTest();
+
+        List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps];
+
+        System.assert(queriedResults.isEmpty(), 'Records should have failed to insert.');
+    }
+
+    private static void scheduleJob() {
+        String jobId = System.schedule('testRefreshScheduledApex',
+            '0 0 10 ? * MON-FRI', 
+         new CampaignListRefreshSchedulable());
+    }
+
+    private static List<Campaign> generateCampaigns(Integer numOfCamps, Boolean refresh) {
+        List<Campaign> listCamps = new List<Campaign>();
+        for (Integer i = 0; i < numOfCamps; i++) {
+            listCamps.add(new Campaign(
+                Name = 'Testing Campaign ' + 1,
+                Campaign_List_Refresh_Automatically__c = refresh));
+        }
+        return listCamps;
+    }
+}

--- a/src/classes/CampaignTriggerHandler_TEST.cls
+++ b/src/classes/CampaignTriggerHandler_TEST.cls
@@ -36,6 +36,7 @@
 public with sharing class CampaignTriggerHandler_TEST {
     @isTest
 	private static void testNewCampsWithoutScheduleNoRefresh() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(1, false);
         Test.startTest();
         insert listNewCamps;
@@ -48,6 +49,7 @@ public with sharing class CampaignTriggerHandler_TEST {
 
     @isTest
     private static void testNewCampsWithoutScheduleWithRefresh() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(1, true);
         Test.startTest();
         try {
@@ -65,6 +67,7 @@ public with sharing class CampaignTriggerHandler_TEST {
 
     @isTest
     private static void testUpdateCampsWithoutScheduleNoRefresh() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(1, false);
         insert listNewCamps;
         for (Campaign newCamps : listNewCamps) {
@@ -82,6 +85,7 @@ public with sharing class CampaignTriggerHandler_TEST {
 
     @isTest
     private static void testUpdateCampsWithoutScheduleWithRefresh() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(1, false);
         insert listNewCamps;
         for (Campaign newCamps : listNewCamps) {
@@ -105,24 +109,23 @@ public with sharing class CampaignTriggerHandler_TEST {
 
     @isTest
     private static void testCampsWithScheduleMixBulk() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(100, false);
         listNewCamps.addAll(generateCampaigns(100, true));
         Test.startTest();
-        scheduleJob();
+        List<AsyncApexJob> listCampRefreshJobs = scheduleJob();
         insert listNewCamps;
         Test.stopTest();
 
         List<Campaign> queriedResults = [SELECT Id FROM Campaign WHERE ID IN :listNewCamps];
-        List<AsyncApexJob> listCampRefreshJobs = [SELECT Id FROM AsyncApexJob
-                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
-                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
 
-        System.assertEquals(listCampRefreshJobs.size(), 1, 'There should be a scheduled job found.');
+        System.assertEquals(listCampRefreshJobs.size(), 1, 'There should be one scheduled job.');
         System.assertEquals(listNewCamps.size(), queriedResults.size(), 'Records should have inserted without issue.');
     }
 
     @isTest
     private static void testCampsWithoutScheduleMixBulk() {
+        CampaignTriggerHandler.validate = true;
         List<Campaign> listNewCamps = generateCampaigns(200, false);
         listNewCamps.addAll(generateCampaigns(200, true));
         Test.startTest();
@@ -139,10 +142,13 @@ public with sharing class CampaignTriggerHandler_TEST {
         System.assert(queriedResults.isEmpty(), 'Records should have failed to insert.');
     }
 
-    private static void scheduleJob() {
+    private static List<AsyncApexJob> scheduleJob() {
         String jobId = System.schedule('testRefreshScheduledApex',
             '0 0 10 ? * MON-FRI', 
-         new CampaignListRefreshSchedulable());
+            new CampaignListRefreshSchedulable());
+        return [SELECT Id FROM AsyncApexJob
+                WHERE JobType = 'ScheduledApex' AND Status ='Queued'
+                AND ApexClass.Name = 'CampaignListRefreshSchedulable'];
     }
 
     private static List<Campaign> generateCampaigns(Integer numOfCamps, Boolean refresh) {

--- a/src/classes/CampaignTriggerHandler_TEST.cls-meta.xml
+++ b/src/classes/CampaignTriggerHandler_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -409,6 +409,14 @@
         <value>There is no saved Campaign List for this campaign.</value>
     </labels>
     <labels>
+        <fullName>CampaignToolsRefreshScheduleValidation</fullName>
+        <categories>CampaignTools,Validation</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>CampaignToolsRefreshScheduleValidation</shortDescription>
+        <value>The nightly batch job required to automatically refresh Campaign Lists hasn&apos;t been scheduled yet. An Administrator must schedule this job before you can use the checkbox. Click &lt;a href=&quot;https://powerofus.force.com/articles/Resource/Create-and-Manage-Campaign-Lists#schedule&quot; target=&quot;_blank&quot;&gt;here&lt;/a&gt; for more information.</value>
+    </labels>
+    <labels>
         <fullName>CampaignToolsReleaseLockException</fullName>
         <categories>CampaignTools,Exceptions</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -34,6 +34,8 @@
         <members>CampaignList_TEST</members>
         <members>CampaignTools_TEST</members>
         <members>CampaignTools_UTIL</members>
+        <members>CampaignTriggerHandler</members>
+        <members>CampaignTriggerHandler_TEST</members>
         <members>DeleteCampaignListMembersBatch</members>
         <members>DeleteCampaignListMembersBatch_TEST</members>
         <members>DeleteCampaignMembersBatch</members>
@@ -57,6 +59,10 @@
         <members>CampaignList</members>
         <members>ProcessSegmentBTN</members>
         <name>ApexPage</name>
+    </types>
+    <types>
+        <members>CampaignTrigger</members>
+        <name>ApexTrigger</name>
     </types>
     <types>
         <members>AddPageMessageEvent</members>
@@ -155,6 +161,7 @@
         <members>CampaignToolsListRefreshStatusQueuedMessage</members>
         <members>CampaignToolsListUpdateMembersExecuteException</members>
         <members>CampaignToolsNoSavedCampaignList</members>
+        <members>CampaignToolsRefreshScheduleValidation</members>
         <members>CampaignToolsReleaseLockException</members>
         <members>JobProgressCompletedLabel</members>
         <members>JobProgressExtendedStatusLabel</members>

--- a/src/triggers/CampaignTrigger.trigger
+++ b/src/triggers/CampaignTrigger.trigger
@@ -1,0 +1,36 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+trigger CampaignTrigger on Campaign (before insert, before update) {
+    if (Trigger.isBefore && Trigger.isInsert) {
+        CampaignTriggerHandler.handleBeforeInsert(Trigger.new);
+    } else if (Trigger.isBefore && Trigger.isUpdate) {
+        CampaignTriggerHandler.handleBeforeUpdate(Trigger.old, Trigger.new);
+    }
+}

--- a/src/triggers/CampaignTrigger.trigger-meta.xml
+++ b/src/triggers/CampaignTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
# Critical Changes

# Changes
 - Prevents a user from setting a Campaign List to automatically refresh when the refresh campaign list scheduled job is not present.

# Issues Closed
