### PR TITLE
Fix bug when report has logical filters and more than 2,000 records

### DIFF
--- a/src/classes/ReportService.cls
+++ b/src/classes/ReportService.cls
@@ -102,6 +102,11 @@ public with sharing class ReportService implements CampaignList.ReportService {
                 pageIndex
             ));
             metadata.setReportFilters(reportFilters);
+            
+            String booleanFilter = metadata.getReportBooleanFilter();
+            if (String.isNotBlank(booleanFilter)) {
+                metadata.setReportBooleanFilter('(' + booleanFilter + ') AND ' + reportFilters.size());
+            }
         }
 
         Reports.ReportResults results = Reports.ReportManager.runReport(


### PR DESCRIPTION
# Critical Changes

# Changes
If report metadata contains boolean filter then wrap it and add a final `AND` to include the new record ID filter that was just appended to the filters list.

# Issues Closed
Fixes issue #94 